### PR TITLE
Правки nullable return type

### DIFF
--- a/src/AmoCRM/Models/AccountModel.php
+++ b/src/AmoCRM/Models/AccountModel.php
@@ -468,7 +468,7 @@ class AccountModel extends BaseApiModel
     /**
      * @return UsersGroupsCollection
      */
-    public function getUsersGroups(): UsersGroupsCollection
+    public function getUsersGroups(): ?UsersGroupsCollection
     {
         return $this->usersGroups;
     }
@@ -487,7 +487,7 @@ class AccountModel extends BaseApiModel
     /**
      * @return TaskTypesCollection
      */
-    public function getTaskTypes(): TaskTypesCollection
+    public function getTaskTypes(): ?TaskTypesCollection
     {
         return $this->taskTypes;
     }

--- a/src/AmoCRM/Models/AccountSettings/UsersGroup.php
+++ b/src/AmoCRM/Models/AccountSettings/UsersGroup.php
@@ -99,7 +99,7 @@ class UsersGroup extends BaseApiModel implements Arrayable
     /**
      * @return string
      */
-    public function getUuid(): string
+    public function getUuid(): ?string
     {
         return $this->uuid;
     }


### PR DESCRIPTION
Пока что не знаю, что за UUID в группах, но он мне не даёт получить данные аккаунта в toArray, т.к. там обязательно string должен возвращаться. Но вот данные моего тестового аккаунта, чистый, свежий. UUID в нём равен null.

```
  object(AmoCRM\Collections\UsersGroupsCollection)#44 (1) {
    ["data":protected]=>
    array(1) {
      [0]=>
      object(AmoCRM\Models\AccountSettings\UsersGroup)#43 (3) {
        ["id":protected]=>
        int(0)
        ["name":protected]=>
        string(23) "Отдел продаж"
        ["uuid":protected]=>
        NULL
      }
    }
  }
```

UPD:
Похожая проблема в AccountModel.
Если получать данные аккаунта без getAvailableWith(), как приводится в examples, тогда getUsersGroups и getTaskTypes тоже могут возвращать null.
```
$client->account()->getCurrent(/* AccountModel::getAvailableWith() */);
```