### PR TITLE
Обновление токена срабатывает несколько раз

### DIFF
--- a/src/AmoCRM/Client/AmoCRMApiClient.php
+++ b/src/AmoCRM/Client/AmoCRMApiClient.php
@@ -128,9 +128,17 @@ class AmoCRMApiClient
     private function buildRequest(): AmoCRMApiRequest
     {
         $oAuthClient = $this->getOAuthClient();
-        if (is_callable($this->accessTokenRefreshCallback)) {
-            $oAuthClient->setAccessTokenRefreshCallback($this->accessTokenRefreshCallback);
-        }
+
+        $oAuthClient->setAccessTokenRefreshCallback(
+            function (AccessToken $accessToken, string $baseAccountDomain) use ($oAuthClient) {
+                $this->setAccessToken($accessToken);
+
+                if (is_callable($this->accessTokenRefreshCallback)) {
+                    $callback = $this->accessTokenRefreshCallback;
+                    $callback($accessToken, $baseAccountDomain);
+                }
+            }
+        );
 
         return new AmoCRMApiRequest($this->accessToken, $oAuthClient);
     }


### PR DESCRIPTION
В AmoCRMApiRequest.php при refreshAccessToken новый токен устанавливается только в текущий экземпляр класса, не обновляя токен в AmoCRMApiClient.php, что приводит к повторному обновлению токена при каждом новом запросе.