### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://img.shields.io/travis/amocrm/amocrm-api-php)](https://travis-ci.org/github/amocrm/amocrm-api-php/)
 [![Total Downloads](https://img.shields.io/packagist/dt/amocrm/amocrm-api-library.svg)](https://packagist.org/packages/amocrm/amocrm-api-library)
 
-В данном пакете представлен API клиент с поддержкой основных сущностей и авторизацией по протоколу OAuth 2.0 в amoCRM.
+В данном пакете представлен API клиент с поддержкой основных сущностей и авторизацией по протоколу OAuth 2.0 в amoCRM. Для работы библиотеки требуется версия php не ниже 7.2 (сами указываете версию)
 
 ## Оглавление
 - [Установка](#установка)


### PR DESCRIPTION
Указать минимальные требования для php. Пример: для работы библиотеки требуется версия php не ниже 7,2 (сами указываете версию). Это необходимо знать перед началом ее использование, так как самое распространенная версия на хостингах это php5,6, и данная библиотека не работала.