### PR TITLE
unlink to link in for contacts examples

### DIFF
--- a/examples/contacts_actions.php
+++ b/examples/contacts_actions.php
@@ -68,7 +68,7 @@ try {
 $links = new LinksCollection();
 $links->add($lead);
 try {
-    $apiClient->contacts()->unlink($contactModel, $links);
+    $apiClient->contacts()->link($contactModel, $links);
 } catch (AmoCRMApiException $e) {
     printError($e);
     die;


### PR DESCRIPTION
В комментарии написано:
//Получим сделку по ID, сделку и привяжем контакт к сделке

В документации:
unlink Отвязать сущность