### PR TITLE
fix shortLinks: multiple links for single id

### DIFF
--- a/src/AmoCRM/EntitiesServices/ShortLinks.php
+++ b/src/AmoCRM/EntitiesServices/ShortLinks.php
@@ -85,7 +85,7 @@ class ShortLinks extends BaseEntity
         $stringKeys = array_filter(
             $collectionKeys,
             /** @param int|string $key */
-            fn ($key) => is_string($key)
+            'is_string'
         );
 
         if (!empty($stringKeys)) {

--- a/src/AmoCRM/EntitiesServices/ShortLinks.php
+++ b/src/AmoCRM/EntitiesServices/ShortLinks.php
@@ -72,19 +72,18 @@ class ShortLinks extends BaseEntity
      * Для корректного сопоставления переданных и возвращённых моделей
      * необходимо убедиться, что коллекция не имеет строковых ключей,
      * и числовые ключи являются последовательностью [0 .. size-1]
-     * 
+     *
      * @param BaseApiCollection
-     * 
+     *
      * @throws StringCollectionKeyException
      * @throws ArrayKeysNotSequentialException
      */
     protected function validateCollectionKeys(BaseApiCollection $collection): void
     {
         $collectionKeys = $collection->keys();
-        
+
         $stringKeys = array_filter(
             $collectionKeys,
-            /** @param int|string $key */
             'is_string'
         );
 
@@ -104,9 +103,9 @@ class ShortLinks extends BaseEntity
     /**
      * Проверка ключей коллекции и добавление коллекции сущностей
      * @param BaseApiCollection
-     * 
+     *
      * @return BaseApiCollection
-     * 
+     *
      * @throws StringCollectionKeyException
      * @throws ArrayKeysNotSequentialException
      * @throws AmoCRMApiException

--- a/src/AmoCRM/EntitiesServices/ShortLinks.php
+++ b/src/AmoCRM/EntitiesServices/ShortLinks.php
@@ -78,8 +78,8 @@ class ShortLinks extends BaseEntity
         $metadatasArray  = array_column($collectionArray, 'metadata');
         $ids             = array_column($metadatasArray, 'entity_id');
         $uniqueIds       = array_unique($ids);
-        $uniqueIdsCount  = count($uniqueIds);
-
+        
+        $uniqueIdsCount       = count($uniqueIds);
         $collectionItemsCount = $collection->count();
 
         if ($uniqueIdsCount < $collectionItemsCount) {

--- a/src/AmoCRM/EntitiesServices/ShortLinks.php
+++ b/src/AmoCRM/EntitiesServices/ShortLinks.php
@@ -7,7 +7,7 @@ use AmoCRM\Helpers\EntityTypesInterface;
 use AmoCRM\Client\AmoCRMApiClient;
 use AmoCRM\Client\AmoCRMApiRequest;
 use AmoCRM\Collections\BaseApiCollection;
-use AmoCRM\Exceptions\ArrayKeysNotSequentialException;
+use AmoCRM\Exceptions\CollectionKeysNotSequentialException;
 use AmoCRM\Exceptions\CollectionAndResponseKeysNotIndenticalException;
 use AmoCRM\Exceptions\NotAvailableForActionException;
 use AmoCRM\Exceptions\StringCollectionKeyException;
@@ -97,7 +97,7 @@ class ShortLinks extends BaseEntity
                                 [] : range(0, $collectionKeysCount - 1);
 
         if ($collectionKeys !== $estimatedKeys) {
-            throw new ArrayKeysNotSequentialException();
+            throw new CollectionKeysNotSequentialException();
         }
     }
 

--- a/src/AmoCRM/Exceptions/ArrayKeysNotSequentialException.php
+++ b/src/AmoCRM/Exceptions/ArrayKeysNotSequentialException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace AmoCRM\Exceptions;
-
-class ArrayKeysNotSequentialException extends AmoCRMApiException
-{
-}

--- a/src/AmoCRM/Exceptions/ArrayKeysNotSequentialException.php
+++ b/src/AmoCRM/Exceptions/ArrayKeysNotSequentialException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace AmoCRM\Exceptions;
+
+class ArrayKeysNotSequentialException extends AmoCRMApiException
+{
+}

--- a/src/AmoCRM/Exceptions/CollectionAndResponseKeysNotIndenticalException.php
+++ b/src/AmoCRM/Exceptions/CollectionAndResponseKeysNotIndenticalException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace AmoCRM\Exceptions;
+
+class CollectionAndResponseKeysNotIndenticalException extends AmoCRMApiException
+{
+}

--- a/src/AmoCRM/Exceptions/CollectionKeysNotSequentialException.php
+++ b/src/AmoCRM/Exceptions/CollectionKeysNotSequentialException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace AmoCRM\Exceptions;
+
+class CollectionKeysNotSequentialException extends AmoCRMApiException
+{
+}

--- a/src/AmoCRM/Exceptions/StringCollectionKeyException.php
+++ b/src/AmoCRM/Exceptions/StringCollectionKeyException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace AmoCRM\Exceptions;
+
+class StringCollectionKeyException extends AmoCRMApiException
+{
+}


### PR DESCRIPTION
Cуществующий метод пакетного создания коротких ссылок работает некорректно: если есть две или более ссылки для одного аккаунта, будет заменена короткой только первая из переданных для этого контакта, при этом вести она будет на последний url, который был передан для этого контакта.
Ошибка в обработке ответа сервера, а не в самом ответе.
Реализация метода processAction в разных сервисах сопоставляет исходную-возвращенную модели по уникальному ключу каждой модели, обычно это id/request_id. Однако, у shortLinks уникального поля нет, сопоставление ведётся по entity_id, который в случае с несколькими ссылками для одного аккаунта не уникален, что и вызывает ошибку.
Предлагаю до момента добавления уникального ключа модели проверять факт наличия одинаковых id в запросе, и если таковые найдены, сопоставлять сущности не по номеру контакта, а по порядку следования в коллекции.


<img src ="https://user-images.githubusercontent.com/54582196/99076656-87648500-25cc-11eb-86a4-2b70fd64960b.png" width="500">

![переход](https://user-images.githubusercontent.com/54582196/99079010-60a84d80-25d0-11eb-98c6-60a1ccd5c9d5.png)
