### PR TITLE
Исправление CallModel.php

### DIFF
--- a/src/AmoCRM/Models/CallModel.php
+++ b/src/AmoCRM/Models/CallModel.php
@@ -110,7 +110,7 @@ class CallModel extends BaseApiModel implements HasIdInterface
         }
 
         if (isset($call['direction'])) {
-            $this->setCallStatus($call['direction']);
+            $this->setDirection($call['direction']);
         }
 
 


### PR DESCRIPTION
В методе fromArray вместо вызова setDirection для установки направления звонка, вызывался метод setCallStatus, которому передавалось значение ключа 'direction', не подходящее по типу. В итоге метод fromArray сваливался в исключение на валидных данных во входном массиве.