### PR TITLE
Laravel 9 и php8.1 compability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "ext-json": "*",
     "amocrm/oauth2-amocrm": "^2.0",
     "guzzlehttp/guzzle": "6.* || 7.*",
-    "illuminate/support": "5.* || 6.* || 7.* || 8.*",
+    "illuminate/support": "5.* || 6.* || 7.* || 8.* || 9.*",
     "symfony/dotenv": "3.* || 4.* || 5.* || 6.*",
     "fig/http-message-util": "1.*",
     "ramsey/uuid": "^3 || ^4",
@@ -31,7 +31,7 @@
     "nesbot/carbon": "^2.52"
   },
   "require-dev": {
-    "phpunit/phpunit": "7.*.*",
+    "phpunit/phpunit": "7.*.* || 9.*.*",
     "squizlabs/php_codesniffer": "3.5.*"
   },
   "autoload": {

--- a/tests/Cases/AmoCRM/Client/AmoCRMApiClientTest.php
+++ b/tests/Cases/AmoCRM/Client/AmoCRMApiClientTest.php
@@ -38,7 +38,7 @@ class AmoCRMApiClientTest extends TestCase
      */
     private $apiClient;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->apiClient = new AmoCRMApiClient('xxx', 'xxx', 'xxx');
         $this->apiClient->setAccessToken(new AccessToken([

--- a/tests/Cases/AmoCRM/Filters/LeadsFilterTest.php
+++ b/tests/Cases/AmoCRM/Filters/LeadsFilterTest.php
@@ -11,7 +11,7 @@ class LeadsFilterTest extends TestCase
      */
     private $leadsFilter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->leadsFilter = new LeadsFilter();
     }


### PR DESCRIPTION
Добавлена возможность установить пакет в laravel 9

Добавлена возможность протестировать работу библиотеки на php 8.1

Скорректировано описание методов setUp, для строгой совместимости