### PR TITLE
fix removing from BaseApiCollection by removeBy() and removeFirstBy()

### DIFF
--- a/src/AmoCRM/Collections/BaseApiCollection.php
+++ b/src/AmoCRM/Collections/BaseApiCollection.php
@@ -408,11 +408,11 @@ abstract class BaseApiCollection implements ArrayAccess, JsonSerializable, Itera
 
         $count = 0;
         if ($getter) {
-            foreach ($this->data as &$object) {
+            foreach ($this->data as $dataKey => $object) {
                 $fieldValue = $object->$getter();
 
                 if ($fieldValue === $value) {
-                    unset($object);
+                    $this->offsetUnset($dataKey);
                     $count++;
                 }
             }
@@ -434,11 +434,11 @@ abstract class BaseApiCollection implements ArrayAccess, JsonSerializable, Itera
         $getter = (method_exists(static::ITEM_CLASS, 'get' . $key) ? 'get' . $key : null);
 
         if ($getter) {
-            foreach ($this->data as &$object) {
+            foreach ($this->data as $dataKey => $object) {
                 $fieldValue = $object->$getter();
 
                 if ($fieldValue === $value) {
-                    unset($object);
+                    $this->offsetUnset($dataKey);
                     return true;
                 }
             }


### PR DESCRIPTION
The fix solving a problem of removing element of BaseApiCollection by removeBy() and removeFirstBy() methods.