### PR TITLE
Реализовано отдельное исключение для 429

### DIFF
--- a/src/AmoCRM/Client/AmoCRMApiRequest.php
+++ b/src/AmoCRM/Client/AmoCRMApiRequest.php
@@ -594,6 +594,9 @@ class AmoCRMApiRequest
             && !$decodedBody
             && !empty($bodyContents)
         ) {
+            if($e->getCode() == 429) {
+                throw new AmoCRMApiTooManyRequestsException("Too many requests", $e->getCode(), $this->getLastRequestInfo());
+            }
             throw new AmoCRMApiException(
                 "Response body is not json",
                 $response->getStatusCode(),

--- a/src/AmoCRM/Exceptions/AmoCRMApiTooManyRequestsException.php
+++ b/src/AmoCRM/Exceptions/AmoCRMApiTooManyRequestsException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace AmoCRM\Exceptions;
+
+/**
+ * Class AmoCRMApiHttpClientException
+ *
+ * Выбрасывается в случае ответа от сервера с кодом 429
+ *
+ * @package AmoCRM\Exceptions
+ */
+class AmoCRMApiTooManyRequestsException extends AmoCRMApiHttpClientException
+{
+}


### PR DESCRIPTION
429 отдаются в json и с точки зрения библиотеки это просто ApiException с текстом "Response body is not json". Реагировать на индцидент в таком варианте сложно. Данный пул решает проблему