### PR TITLE
Исправление значения с 30 часов до 30 минут

### DIFF
--- a/examples/tasks_actions.php
+++ b/examples/tasks_actions.php
@@ -33,7 +33,7 @@ $task->setTaskTypeId(TaskModel::TASK_TYPE_ID_FOLLOW_UP)
     ->setCompleteTill(mktime(10, 0, 0, 10, 3, 2020))
     ->setEntityType(EntityTypesInterface::LEADS)
     ->setEntityId(1)
-    ->setDuration(30 * 60 * 60) //30 минут
+    ->setDuration(30 * 60) //30 минут
     ->setResponsibleUserId(123);
 $tasksCollection->add($task);
 


### PR DESCRIPTION
Здравствуйте!

Я тут при изучений AmoCRM API столкнулся с ошибочным кодом в котором вместо 30 минут указан около 15 часов, а в комментах написано 30 мин. За этим я возился час :sweat_smile: пока не заметил что тут лишняя *60 что и отправляет  запросы с неправильной длительностью Задачи. :cry: 

Хотелось бы исправить это :sweat_smile: 