### PR TITLE
(Examples - Task) Правка калькуляции длительности

### DIFF
--- a/examples/tasks_actions.php
+++ b/examples/tasks_actions.php
@@ -33,7 +33,7 @@ $task->setTaskTypeId(TaskModel::TASK_TYPE_ID_FOLLOW_UP)
     ->setCompleteTill(mktime(10, 0, 0, 10, 3, 2020))
     ->setEntityType(EntityTypesInterface::LEADS)
     ->setEntityId(1)
-    ->setDuration(30 * 60 * 60) //30 минут
+    ->setDuration(30 * 60) //30 минут
     ->setResponsibleUserId(123);
 $tasksCollection->add($task);
 


### PR DESCRIPTION
Здравствуйте!

Я тут при изучений AmoCRM API столкнулся с ошибочным кодом в котором вместо 30 минут указан 30 часов, а в комментах написано 30 мин. За этим я возился час 😅 пока не заметил что тут лишняя *60 что и отправляет запросы с неправильной длительностью Задачи. 😢

Хотелось бы исправить это 😅