### PR TITLE
fix get subdomain in refresh token request

### DIFF
--- a/src/AmoCRM/OAuth/AmoCRMOAuth.php
+++ b/src/AmoCRM/OAuth/AmoCRMOAuth.php
@@ -164,7 +164,9 @@ class AmoCRMOAuth
                 'refresh_token' => $accessToken->getRefreshToken(),
             ]);
         } catch (IdentityProviderException $e) {
-            if ($e->getCode() === StatusCodeInterface::STATUS_NOT_FOUND) {
+            if (in_array(
+                $e->getCode(), [StatusCodeInterface::STATUS_NOT_FOUND, StatusCodeInterface::STATUS_UNAUTHORIZED], true
+            )) {
                 $accountDomainModel = $this->getAccountDomainByRefreshToken($accessToken);
                 $this->setBaseDomain($accountDomainModel->getDomain());
 

--- a/src/AmoCRM/OAuth/AmoCRMOAuth.php
+++ b/src/AmoCRM/OAuth/AmoCRMOAuth.php
@@ -164,13 +164,32 @@ class AmoCRMOAuth
                 'refresh_token' => $accessToken->getRefreshToken(),
             ]);
         } catch (IdentityProviderException $e) {
-            throw new AmoCRMoAuthApiException(
-                $e->getMessage(),
-                $e->getCode(),
-                [],
-                $e->getResponseBody(),
-                $e
-            );
+            if ($e->getCode() === StatusCodeInterface::STATUS_NOT_FOUND) {
+                $accountDomainModel = $this->getAccountDomainByRefreshToken($accessToken);
+                $this->setBaseDomain($accountDomainModel->getDomain());
+
+                try {
+                    $accessToken = $this->oauthProvider->getAccessToken(new RefreshToken(), [
+                        'refresh_token' => $accessToken->getRefreshToken(),
+                    ]);
+                } catch (IdentityProviderException $e) {
+                    throw new AmoCRMoAuthApiException(
+                        $e->getMessage(),
+                        $e->getCode(),
+                        [],
+                        $e->getResponseBody(),
+                        $e
+                    );
+                }
+            } else {
+                throw new AmoCRMoAuthApiException(
+                    $e->getMessage(),
+                    $e->getCode(),
+                    [],
+                    $e->getResponseBody(),
+                    $e
+                );
+            }
         }
 
         if (is_callable($this->accessTokenRefreshCallback)) {


### PR DESCRIPTION
добавил получение домена с помощью нового метода в случае если не найдено аккаунта по установленному домену