### PR TITLE
Fix: Add null-check before assigning call_status and call_result

### DIFF
--- a/src/AmoCRM/Models/CallModel.php
+++ b/src/AmoCRM/Models/CallModel.php
@@ -197,6 +197,14 @@ class CallModel extends BaseApiModel implements HasIdInterface
             $call['updated_at'] = $updatedAt;
         }
 
+        if ($callStatus = $this->getCallStatus()) {
+            $call['call_status'] = $callStatus;
+        }
+
+        if ($callResult = $this->getCallResult()) {
+            $call['call_result'] = $callResult;
+        }
+
         return $call;
     }
 


### PR DESCRIPTION
- Added null-check for `call_status` and `call_result` to prevent assigning `null` values to the `$call` array.
- Both values are now added only if they are not `null` or empty.
- This prevents sending unnecessary `null` values in requests.

[issue 570](https://github.com/amocrm/amocrm-api-php/issues/570)
