### PR TITLE
Заменил LooseValidAt на ValidAt для обеспечения поддержки старых версий

### DIFF
--- a/src/AmoCRM/OAuth/AmoCRMOAuth.php
+++ b/src/AmoCRM/OAuth/AmoCRMOAuth.php
@@ -571,13 +571,13 @@ class AmoCRMOAuth
                 $constraint->assert($jwtToken);
             }
         } catch (ConstraintViolation $e) {
-            $validAtConstraint = get_class($validAtConstraint);
+            $validAtConstraintClassName = get_class($validAtConstraint);
             switch (true) {
                 case $constraint instanceof SignedWith:
                     throw DisposableTokenVerificationFailedException::create();
                 case $constraint instanceof PermittedFor:
                     throw DisposableTokenInvalidDestinationException::create();
-                case $constraint instanceof $validAtConstraint:
+                case $constraint instanceof $validAtConstraintClassName:
                     throw DisposableTokenExpiredException::create();
             }
         }
@@ -626,13 +626,13 @@ class AmoCRMOAuth
                 $constraint->assert($jwtToken);
             }
         } catch (ConstraintViolation $e) {
-            $validAtConstraint = get_class($validAtConstraint);
+            $validAtConstraintClassName = get_class($validAtConstraint);
             switch (true) {
                 case $constraint instanceof SignedWith:
                     throw DisposableTokenVerificationFailedException::create();
                 case $constraint instanceof PermittedFor:
                     throw DisposableTokenInvalidDestinationException::create();
-                case $constraint instanceof $validAtConstraint:
+                case $constraint instanceof $validAtConstraintClassName:
                     throw DisposableTokenExpiredException::create();
             }
         }

--- a/src/AmoCRM/OAuth/AmoCRMOAuth.php
+++ b/src/AmoCRM/OAuth/AmoCRMOAuth.php
@@ -549,6 +549,7 @@ class AmoCRMOAuth
     {
         $signer = new Sha256();
         $key = InMemory::plainText($this->clientSecret);
+
         $validAtConstraint = $this->createValidAtConstraint();
 
         $clientBaseUri = new Uri($this->redirectUri);
@@ -604,6 +605,7 @@ class AmoCRMOAuth
         $key = InMemory::plainText($this->clientSecret);
 
         $validAtConstraint = $this->createValidAtConstraint();
+
         $constraints = [
             // Проверка подписи
             new SignedWith($signer, $key),

--- a/src/AmoCRM/OAuth/AmoCRMOAuth.php
+++ b/src/AmoCRM/OAuth/AmoCRMOAuth.php
@@ -549,7 +549,6 @@ class AmoCRMOAuth
     {
         $signer = new Sha256();
         $key = InMemory::plainText($this->clientSecret);
-
         $validAtConstraint = $this->createValidAtConstraint();
 
         $clientBaseUri = new Uri($this->redirectUri);
@@ -572,6 +571,7 @@ class AmoCRMOAuth
                 $constraint->assert($jwtToken);
             }
         } catch (ConstraintViolation $e) {
+            $validAtConstraint = get_class($validAtConstraint);
             switch (true) {
                 case $constraint instanceof SignedWith:
                     throw DisposableTokenVerificationFailedException::create();
@@ -626,6 +626,7 @@ class AmoCRMOAuth
                 $constraint->assert($jwtToken);
             }
         } catch (ConstraintViolation $e) {
+            $validAtConstraint = get_class($validAtConstraint);
             switch (true) {
                 case $constraint instanceof SignedWith:
                     throw DisposableTokenVerificationFailedException::create();

--- a/src/AmoCRM/OAuth/AmoCRMOAuth.php
+++ b/src/AmoCRM/OAuth/AmoCRMOAuth.php
@@ -675,6 +675,17 @@ class AmoCRMOAuth
 
         return $apiDomain;
     }
+
+    /**
+     * Создает и возвращает объект ограничения проверки времени действия токена.
+     *
+     * Метод динамически выбирает между `LooseValidAt` и `ValidAt` (приоритет у `LooseValidAt`).
+     * Также автоматически выбирает подходящий класс часов (`FrozenClock` или `SystemClock`).
+     *
+     * @psalm-suppress UndefinedClass
+     * @return object
+     * @throws \RuntimeException Если ни один из классов `LooseValidAt` или `ValidAt` недоступен.
+     */
     private function createValidAtConstraint(): object
     {
         $availableConstraints = [

--- a/src/AmoCRM/OAuth/AmoCRMOAuth.php
+++ b/src/AmoCRM/OAuth/AmoCRMOAuth.php
@@ -32,7 +32,6 @@ use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Validation\Constraint;
 use Lcobucci\JWT\Validation\Constraint\PermittedFor;
 use Lcobucci\JWT\Validation\Constraint\SignedWith;
-use Lcobucci\JWT\Validation\Constraint\ValidAt;
 use Lcobucci\JWT\Validation\ConstraintViolation;
 use League\OAuth2\Client\Grant\AuthorizationCode;
 use League\OAuth2\Client\Grant\RefreshToken;

--- a/src/AmoCRM/OAuth/AmoCRMOAuth.php
+++ b/src/AmoCRM/OAuth/AmoCRMOAuth.php
@@ -24,7 +24,6 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\TooManyRedirectsException;
 use GuzzleHttp\Psr7\Uri;
-use Lcobucci\Clock\FrozenClock;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Hmac\Sha256;
 use Lcobucci\JWT\Signer\Hmac\Sha512;

--- a/src/AmoCRM/OAuth/AmoCRMOAuth.php
+++ b/src/AmoCRM/OAuth/AmoCRMOAuth.php
@@ -32,7 +32,7 @@ use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Validation\Constraint;
 use Lcobucci\JWT\Validation\Constraint\PermittedFor;
 use Lcobucci\JWT\Validation\Constraint\SignedWith;
-use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
+use Lcobucci\JWT\Validation\Constraint\ValidAt;
 use Lcobucci\JWT\Validation\ConstraintViolation;
 use League\OAuth2\Client\Grant\AuthorizationCode;
 use League\OAuth2\Client\Grant\RefreshToken;
@@ -560,7 +560,7 @@ class AmoCRMOAuth
             // Проверим наш ли адресат
             new PermittedFor($clientBaseUri),
             // Проверка жизни токена
-            new LooseValidAt(FrozenClock::fromUTC()),
+            new ValidAt(FrozenClock::fromUTC()),
         ];
 
         $configuration = Configuration::forSymmetricSigner($signer, $key);
@@ -577,7 +577,7 @@ class AmoCRMOAuth
                     throw DisposableTokenVerificationFailedException::create();
                 case $constraint instanceof PermittedFor:
                     throw DisposableTokenInvalidDestinationException::create();
-                case $constraint instanceof LooseValidAt:
+                case $constraint instanceof ValidAt:
                     throw DisposableTokenExpiredException::create();
             }
         }
@@ -607,7 +607,7 @@ class AmoCRMOAuth
             // Проверка подписи
             new SignedWith($signer, $key),
             // Проверка жизни токена, с 4.2 deprecated use LooseValidAt
-            new LooseValidAt(FrozenClock::fromUTC()),
+            new ValidAt(FrozenClock::fromUTC()),
         ];
 
         if ($receiverPath !== null) {
@@ -630,7 +630,7 @@ class AmoCRMOAuth
                     throw DisposableTokenVerificationFailedException::create();
                 case $constraint instanceof PermittedFor:
                     throw DisposableTokenInvalidDestinationException::create();
-                case $constraint instanceof LooseValidAt:
+                case $constraint instanceof ValidAt:
                     throw DisposableTokenExpiredException::create();
             }
         }

--- a/src/AmoCRM/OAuth/AmoCRMOAuth.php
+++ b/src/AmoCRM/OAuth/AmoCRMOAuth.php
@@ -693,6 +693,4 @@ class AmoCRMOAuth
 
         throw new \RuntimeException("Neither LooseValidAt nor ValidAt are available.");
     }
-
-
 }


### PR DESCRIPTION
В рамках этого изменения было выполнено следующее:

    Заменен класс LooseValidAt на ValidAt в коде, чтобы обеспечить поддержку более старых версий библиотеки lcobucci/jwt, которые используют ValidAt вместо LooseValidAt.
    Класс ValidAt является устаревшим и использует тот же функционал, что и LooseValidAt, но является более совместимым с предыдущими версиями. Это изменение позволяет работать с кодом, который не был обновлён до последних версий lcobucci/jwt.
 
Причина изменений:

Для обеспечения обратной совместимости с более старыми версиями библиотеки, где использовался класс ValidAt. Это необходимо для тех пользователей, которые не обновили свою библиотеку до последних версий.