### PR TITLE
⚠️⚠️⚠️ Bugfix: deprecated syntax in php8.4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
+[*.php]
+ij_any_align_multiline_parameters = false
+ij_php_space_after_type_cast = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ php:
   - 7.4
   - 8.0
   - 8.1
+  - 8.2
+  - 8.3
+  - 8.4
 
 install:
   - if [[ $MINIMUM_VERSIONS = false ]]; then composer install; fi

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://app.travis-ci.com/amocrm/amocrm-api-php.svg?branch=master)](https://app.travis-ci.com/amocrm/amocrm-api-php)
 [![Total Downloads](https://img.shields.io/packagist/dt/amocrm/amocrm-api-library.svg)](https://packagist.org/packages/amocrm/amocrm-api-library)
 
-В данном пакете представлен API клиент с поддержкой основных сущностей и авторизацией по протоколу OAuth 2.0 в amoCRM. 
+В данном пакете представлен API клиент с поддержкой основных сущностей и авторизацией по протоколу OAuth 2.0 в amoCRM.
 Для работы библиотеки требуется PHP версии не ниже 7.1.
 
 ## Оглавление
@@ -127,7 +127,7 @@ $apiClient = $apiClient->setUserAgnet('App Name');
 
 Вы можете установить функцию-callback на событие обработки ответа, если есть необходимость в дополнительной логике (например логировать ответ от сервера или же переопределить обработку 204 кода ответа).
 
-Если нет необходимости в отработке стандартной логики обработки ответа, то callback должен возвращать true 
+Если нет необходимости в отработке стандартной логики обработки ответа, то callback должен возвращать true
 
 ```php
 $apiClient = new \AmoCRM\Client\AmoCRMApiClient($clientId, $clientSecret, $redirectUri);
@@ -225,7 +225,7 @@ $leadsService = $apiClient->leads();
 | customersSegments    | Сегменты покупателей          |
 | events               | Список событий                |
 | eventTypes           | Типы событий                  |
-| webhooks             | Вебхуки                       | 
+| webhooks             | Вебхуки                       |
 | unsorted             | Неразобранное                 |
 | pipelines            | Воронки сделок                |
 | statuses             | Статусы сделок                |
@@ -264,16 +264,16 @@ $leadsService = $apiClient->leads();
     2. with (array) - массив параметров with, которые поддерживает модель сервиса
     3. Результатом выполнения будет коллекция сущностей
     ```php
-    get(BaseEntityFilter $filter = null, array $with = []);
+    get(?BaseEntityFilter $filter = null, array $with = []);
     ```
-   
+
 3. addOne Создать одну сущность:
     1. model (BaseApiModel) - модель создаваемой сущности
     2. Результатом выполнения будет модель сущности
     ```php
     addOne(BaseApiModel $model);
     ```
-   
+
 4. add Создать сущности пакетно:
     1. collection (BaseApiCollection) - коллекция моделей создаваемой сущности
     2. Результатом выполнения будет коллекция моделей сущности
@@ -287,14 +287,14 @@ $leadsService = $apiClient->leads();
     ```php
     updateOne(BaseApiModel $model);
     ```
-   
+
 6. update Обновить сущности пакетно:
     1. collection (BaseApiCollection) - коллекция моделей создаваемой сущности
     2. Результатом выполнения будет коллекция моделей сущности
     ```php
     update(BaseApiCollection $collection);
     ```
-   
+
 7. syncOne Синхронизировать одну модель с сервером:
     1. model (BaseApiModel) - коллекция моделей создаваемой сущности
     2. with (array) - массив параметров with, которые поддерживает модель сервиса
@@ -302,7 +302,7 @@ $leadsService = $apiClient->leads();
     ```php
     syncOne(BaseApiModel $model, $with = []);
     ```
-   
+
 Не все методы доступны во всех сервисах. В случае их вызова будет выброшены Exception.
 
 Некоторые сервисы имеют специфичные методы, ниже рассмотрим сервисы, которые имеют специфичные методы.
@@ -331,21 +331,21 @@ $leadsService = $apiClient->leads();
     ```php
     getAuthorizeUrl(array $options = []);
     ```
-   
+
 2. getAccessTokenByCode получение access токена по коду авторизации
     1. code (string) код авторизации
     2. Результатом выполнения будет объект (AccessTokenInterface)
     ```php
     getAccessTokenByCode(string $code);
     ```
-   
+
 3. getAccessTokenByRefreshToken получение access токена по refresh токену
     1. accessToken (AccessTokenInterface) объект access токена
     2. Результатом выполнения будет объект (AccessTokenInterface)
     ```php
     getAccessTokenByRefreshToken(AccessTokenInterface $accessToken);
     ```
-   
+
 4. setBaseDomain установка базового домена, куда будут отправляться запросы необходимые для работы с токенами
     1. domain (string)
     ```php
@@ -371,7 +371,7 @@ $leadsService = $apiClient->leads();
     ```php
     getOAuthButton(array $options = []);
     ```
-   
+
 7. exchangeApiKey метод для обмена API ключа на код авторизации
     1. login - email пользователя, для которого обменивается API ключ
     2. apiKey - API ключ пользователя
@@ -397,7 +397,7 @@ $leadsService = $apiClient->leads();
     ```php
     getLinks(BaseApiModel $model, LinksFilter $filter);
     ```
-       
+
 3. unlink Отвязать сущность
     1. model (BaseApiModel) - модель главной сущности
     2. links (LinksCollection|LinkModel) - коллекция или модель связи
@@ -414,7 +414,7 @@ $leadsService = $apiClient->leads();
     ```php
     deleteOne(BaseApiModel $model);
     ```
-   
+
 2. deleteOne
     1. collection (BaseApiCollection) - коллекция моделей сущностей
     2. Результатом выполнения является bool значение
@@ -452,7 +452,7 @@ $leadsService = $apiClient->leads();
     2. filter (BaseEntityFilter) - фильтр
     3. with (array) - массив параметров with, которые поддерживает модель сервиса
     ```php
-   getByParentId(int $parentId, BaseEntityFilter $filter = null, array $with = []);
+   getByParentId(int $parentId, ?BaseEntityFilter $filter = null, array $with = []);
     ```
 
 #### Методы доступные в сервисе ```account```
@@ -470,7 +470,7 @@ $leadsService = $apiClient->leads();
     ```php
     addOne(BaseApiModel $model);
     ```
-   
+
 2. add Создать сущности пакетно:
     1. collection (BaseApiCollection) - коллекция моделей создаваемой сущности
     2. Результатом выполнения будет коллекция моделей сущности
@@ -480,15 +480,15 @@ $leadsService = $apiClient->leads();
 
 3. link
     1. model (BaseApiModel) - модель неразобранного
-    2. body (array) - массив дополнительной информации для привязки 
+    2. body (array) - массив дополнительной информации для привязки
     3. Результатом выполнения будет модель LinkUnsortedModel
     ```php
     link(BaseApiModel $unsortedModel, $body = []);
     ```
-   
+
 4. accept
     1. model (BaseApiModel) - модель неразобранного
-    2. body (array) - массив дополнительной информации для принятия 
+    2. body (array) - массив дополнительной информации для принятия
     3. Результатом выполнения будет модель AcceptUnsortedModel
     ```php
     accept(BaseApiModel $unsortedModel, $body = []);
@@ -496,7 +496,7 @@ $leadsService = $apiClient->leads();
 
 5. decline
     1. model (BaseApiModel) - модель неразобранного
-    2. body (array) - массив дополнительной информации для отклонения 
+    2. body (array) - массив дополнительной информации для отклонения
     3. Результатом выполнения будет модель DeclineUnsortedModel
     ```php
     decline(BaseApiModel $unsortedModel, $body = []);
@@ -516,7 +516,7 @@ $leadsService = $apiClient->leads();
     ```php
     subscribe(WebhookModel $webhookModel);
     ```
-   
+
 2. unsubscribe
     1. model (WebhookModel) - модель вебхука
     2. Результатом выполнения является bool значение
@@ -531,7 +531,7 @@ $leadsService = $apiClient->leads();
     ```php
     install(WidgetModel $widgetModel);
     ```
-   
+
 2. uninstall
     1. model (WidgetModel) - модель виджета
     2. Результатом выполнения является модель WidgetModel
@@ -545,7 +545,7 @@ $leadsService = $apiClient->leads();
     ```php
     settings();
     ```
-   
+
 2. updateSettings
     1. model (ProductsSettingsModel) - модель виджета
     2. Результатом выполнения является модель ProductsSettingsModel
@@ -582,7 +582,7 @@ $leadsService = $apiClient->leads();
    2. with (array) - массив параметров with, которые поддерживает модель сервиса
    3. Результатом выполнения будет коллекция ```WebsiteButtonsCollection``` из сущностей ```WebsiteButtonModel```
     ```php
-    get(BaseEntityFilter $filter = null, array $with = []);
+    get(?BaseEntityFilter $filter = null, array $with = []);
     ```
 3. createAsync - добавить источник типа "кнопка на сайт"
    1. model (WebsiteButtonCreateRequestModel) - модель со свойствами:
@@ -672,10 +672,10 @@ $leadsService = $apiClient->leads();
 6. ```segments```
 
 У моделей, которые возвращаются этими сервисами, поля можно получить через метод ```getCustomFieldsValues()```.
-На вызов данного метода возвращается объект ```CustomFieldsValuesCollection``` или ```null```, 
+На вызов данного метода возвращается объект ```CustomFieldsValuesCollection``` или ```null```,
 если значений полей нет.
 
-Внутри коллекции ```CustomFieldsValuesCollection``` находятся модели значений полей, 
+Внутри коллекции ```CustomFieldsValuesCollection``` находятся модели значений полей,
 все модели наследуются от ```BaseCustomFieldValuesModel```, но зависят от типа поля.
 
 У моделей, наследующих ```BaseCustomFieldValuesModel``` доступны следующие методы:
@@ -753,7 +753,7 @@ $textCustomFieldValuesModel->setValues(
 $leadCustomFieldsValues->add($textCustomFieldValuesModel);
 //Установим в сущности эти поля
 $lead->setCustomFieldsValues($leadCustomFieldsValues);
-``` 
+```
 
 Чтобы удалить значения поля доступен специальный объект ```\AmoCRM\Models\CustomFieldsValues\ValueCollections\NullCustomFieldValueCollection```.
 
@@ -849,7 +849,7 @@ $lead->setTags((new NullTagsCollection()));
 
 При добавлении источника обязательными полями являются `external_id`, `name` интеграция может создать в аккаунте
 не более 50 активных источников на аккаунт. При удалении источника, к примеру, со значением `external_id: 'sales'`
-и при повторном создании с тем же `external_id` crm может вернуть `id` раннее удаленного источника. Поэтому не стоит 
+и при повторном создании с тем же `external_id` crm может вернуть `id` раннее удаленного источника. Поэтому не стоит
 на стороне интеграции формировать первичный ключ из поля `id`.
 
 Чтобы источник отображался в кнопке whatsapp CRM Plugin необходимо указать поле источника `services` с таким содержимым:
@@ -876,37 +876,37 @@ $lead->setTags((new NullTagsCollection()));
 по-умолчанию в сделках будет указан источник АПИ-интеграция с названием интеграции (как при создании неразобранного через АПИ).
 
 Чтобы сменить источник по-умолчанию, достаточно нужному источнику проставить поле `default=true`, у предыдущего источника
-поле default будет выставлено в `default=false`. Но при удалении источника по-умолчанию интеграция сама должна указать 
+поле default будет выставлено в `default=false`. Но при удалении источника по-умолчанию интеграция сама должна указать
 новый источник по-умолчанию.
 
 ### Миграция интеграции на множественные источники (для интеграций с чатами)
 
 Источник по-умолчанию может быть использован интеграцией при переходе на множественные источники, особенно если
-интеграция поддерживает опцию написать первым. 
+интеграция поддерживает опцию написать первым.
 
-К примеру исходное состояние:  
-   Есть аккаунт с подключенной интеграцией с чатами, эта интеграция поддерживает только 1 источник. 
+К примеру исходное состояние:
+   Есть аккаунт с подключенной интеграцией с чатами, эта интеграция поддерживает только 1 источник.
    На данный момент нам не важно как была установлена интеграция: через DP или маркетплейс.
 
-Интеграция начинает внедрение поддержки множественных источников, логически разобьем на этапы:  
+Интеграция начинает внедрение поддержки множественных источников, логически разобьем на этапы:
 
-**1 этап**   
-Интеграция умеет работать с АПИ источниками (но не отправляет и не принимает источник в сообщениях amojo). 
-Добавляет источник по-умолчанию, который логически соответствует источнику, использовавшемуся когда не было поддержки нескольких источников. Теперь crm будет присылать в сообщениях `external_id` этого источника для всех чатов которые явно 
+**1 этап**
+Интеграция умеет работать с АПИ источниками (но не отправляет и не принимает источник в сообщениях amojo).
+Добавляет источник по-умолчанию, который логически соответствует источнику, использовавшемуся когда не было поддержки нескольких источников. Теперь crm будет присылать в сообщениях `external_id` этого источника для всех чатов которые явно
 не закреплены за конкретным источником.
 
-**2 этап**  
+**2 этап**
 Интеграция умеет работать с источниками и при отправке сообщений от клиента (при создании чата) указывает `external_id`
-Все чаты с новыми сообщениями становятся размеченными по источнику. 
+Все чаты с новыми сообщениями становятся размеченными по источнику.
 
 Так же интеграция теперь обрабатывает источник и учитывает его при отправке сообщения от менеджера, в том числе при начале чата с клиентом (опция "написать первым").
 
-**3 этап**  
+**3 этап**
 Интеграция позволяет администратору аккаунта добавить (через интеграцию) второй и последующие источники.
 Вся переписка числится за каким-то источником
 
 **Важный момент**
-Источник по-умолчанию не привязывается к чатам, если его явно не передавали с сообщениями и тогда при смене 
+Источник по-умолчанию не привязывается к чатам, если его явно не передавали с сообщениями и тогда при смене
 источника по-умолчанию чат без разметки будет "числиться" за новым источником
 
 ## Константы
@@ -923,7 +923,7 @@ $lead->setTags((new NullTagsCollection()));
 7. ```\AmoCRM\Models\Rights\RightModel``` - константы, связанные с правами
 8. ```\AmoCRM\Models\AccountModel``` - константы для аргумента with для сервиса ```account```
 9. ```\AmoCRM\Models\TaskModel``` - константы для дефолтных типов задач
-10. ```\AmoCRM\Models\NoteType\TargetingNote``` - константы поддерживаемых внешних сервисов для примечаний о таргетинге (добавляют DP) 
+10. ```\AmoCRM\Models\NoteType\TargetingNote``` - константы поддерживаемых внешних сервисов для примечаний о таргетинге (добавляют DP)
 11. ```\AmoCRM\Models\RoleModel``` - константы для аргумента with для сервиса ```roles```
 12. ```\AmoCRM\Models\Factories\NoteFactory``` - константы типов примечаний
 13. ```\AmoCRM\Models\NoteType\MessageCashierNote``` - статусы примечания "Сообщение кассиру"
@@ -955,7 +955,7 @@ $lead->setTags((new NullTagsCollection()));
  *
  * @example examples/get_account_subdomain.php
  */
-$accountDomain = $apiClient->getOAuthClient()
+use AmoCRM\Models\AccountDomainModel;$accountDomain = $apiClient->getOAuthClient()
         ->getAccountDomain($accessToken);
 
 // Возьмём из полученной модели текущий subdomain аккаунта и засетим наш апи клиент
@@ -964,10 +964,11 @@ $apiClient->setAccountBaseDomain($accountDomain->getSubdomain());
 ```
 
 ## Одноразовые токены интеграций, расшифровка
+
 ```php
 // Как пример, получим заголовки с реквеста
 // И получим нужный нам X-Auth-Token
-$token = $_SERVER['HTTP_X_AUTH_TOKEN'];
+use AmoCRM\Models\DisposableTokenModel;$token = $_SERVER['HTTP_X_AUTH_TOKEN'];
 
 try {
     /**
@@ -1002,8 +1003,9 @@ try {
 ```
 Также вы можете распарсить и модель одноразового токена для Salesbot/Marketingbot.
 Для этого необходимо сделать вызов метода `parseBotDisposableToken`:
+
 ```php
-$token = 'XXX';
+use AmoCRM\Models\BotDisposableTokenModel;$token = 'XXX';
 try {
     /**
      * Одноразовый токен для ботов, его вы можете получить, сделав вызов widget_request в виджете в боте
@@ -1011,7 +1013,7 @@ try {
      *
      * Данный токен содержит в себе информацию об аккаунте и о сущности, с которой работает бот
      * Для продолжения бота необходимо сделать запрос на метод, который был получен в теле хука
-     * Подробнее: @link https://www.amocrm.ru/developers/content/crm_platform/widgets-api#widget-continue  
+     * Подробнее: @link https://www.amocrm.ru/developers/content/crm_platform/widgets-api#widget-continue
      *
      * Расшифруем пришедший токен и получим модель с информацией
      * Подробнее: @see BotDisposableTokenModel
@@ -1079,7 +1081,7 @@ CLIENT_REDIRECT_URI="https://example.com/examples/get_token.php (Важно об
 
 Затем вы можете поднять локальный сервер командой ```composer serve```. После конфигурации необходимо перейти в браузере на страницу
 ```http://localhost:8181/examples/get_token.php``` для получения Access Token.
-Для получения доступа к вашему локальному серверу извне можно использовать сервис ngrok.io. 
+Для получения доступа к вашему локальному серверу извне можно использовать сервис ngrok.io.
 
 После авторизации вы можете проверить работу примеров, обращаясь к ним из браузера. Стоит отметить, что для корректной работы примеров
 необходимо проверить ID сущностей в них.
@@ -1093,7 +1095,7 @@ CLIENT_REDIRECT_URI="https://example.com/examples/get_token.php (Важно об
 
 Также могут быть рассмотрены пожелания по улучшению библиотеки.
 
-Вы можете предложить свои исправления/изменения исходного кода библиотеки, посредством создания Issue с описанием, а также Pull request с упоминанием Issue в комментарии к нему. 
+Вы можете предложить свои исправления/изменения исходного кода библиотеки, посредством создания Issue с описанием, а также Pull request с упоминанием Issue в комментарии к нему.
 Они будут рассмотрены и будут приняты или отклонены. Некоторые Pull Request могут остаться без ответа и действия, в случае, если правки потенциально жизнеспособны, но в данный момент не являются ключевыми для проекта.
 
 Если вы столкнулись с проблемой функционала amoCRM - обратитесь в техническую поддержку через чат в вашем аккаунте.

--- a/composer.json
+++ b/composer.json
@@ -20,35 +20,25 @@
   ],
   "require": {
     "php": ">=7.1 || >=8.0",
+    "ext-fileinfo": "*",
     "ext-json": "*",
     "amocrm/oauth2-amocrm": "^2.0",
-    "guzzlehttp/guzzle": "6.* || 7.*",
-    "symfony/dotenv": "3.* || 4.* || 5.* || 6.* || 7.*",
     "fig/http-message-util": "1.*",
-    "ramsey/uuid": "^3 || ^4",
-    "lcobucci/jwt": "^3.4.6 || ^4.0.4",
+    "guzzlehttp/guzzle": "6.* || 7.*",
     "lcobucci/clock": "1.1.0 ||^2.0.0",
+    "lcobucci/jwt": "^3.4.6 || ^4.0.4",
     "nesbot/carbon": "^2.72.6 || ^3.8.4",
-    "ext-fileinfo": "*"
+    "ramsey/uuid": "^3 || ^4",
+    "symfony/dotenv": "3.* || 4.* || 5.* || 6.* || 7.*"
   },
   "require-dev": {
     "phpunit/phpunit": "7.* || 8.* || 9.*",
+    "roave/security-advisories": "dev-latest",
     "squizlabs/php_codesniffer": "^3.5.2"
   },
   "autoload": {
     "psr-4": {
-      "AmoCRM\\": "src/",
-      "AmoCRM\\Client\\": "src/AmoCRM/Client",
-      "AmoCRM\\Enum\\": "src/AmoCRM/Enum",
-      "AmoCRM\\OAuth\\": "src/AmoCRM/OAuth",
-      "AmoCRM\\EntitiesServices\\": "src/AmoCRM/EntitiesServices",
-      "AmoCRM\\Exceptions\\": "src/AmoCRM/Exceptions",
-      "AmoCRM\\Models\\": "src/AmoCRM/Models",
-      "AmoCRM\\Collections\\": "src/AmoCRM/Collections",
-      "AmoCRM\\Filters\\": "src/AmoCRM/Filters",
-      "AmoCRM\\Helpers\\": "src/AmoCRM/Helpers",
-      "AmoCRM\\Contracts\\": "src/AmoCRM/Contracts",
-      "AmoCRM\\Support\\": "src/AmoCRM/Support"
+      "AmoCRM\\": "src/AmoCRM"
     }
   },
   "scripts": {
@@ -60,5 +50,8 @@
       "@style:check",
       "@test"
     ]
+  },
+  "config": {
+    "sort-packages": true
   }
 }

--- a/examples/contacts_actions.php
+++ b/examples/contacts_actions.php
@@ -82,8 +82,9 @@ try {
     die;
 }
 
-//Работает только, если уже существует что то внутри getCustomFieldsValues(). В противном случае возвращает null и следует использовать setCustomFieldsValues 
-//Получим коллекцию значений полей контакта
+// Работает только, если уже существует что-то внутри getCustomFieldsValues().
+// В противном случае возвращает null и следует использовать setCustomFieldsValues.
+// Получим коллекцию значений полей контакта
 $customFields = $contact->getCustomFieldsValues();
 //Получим значение поля по его коду
 $phoneField = $customFields->getBy('fieldCode', 'PHONE');

--- a/examples/get_account_subdomain.php
+++ b/examples/get_account_subdomain.php
@@ -1,6 +1,7 @@
 <?php
 
 use AmoCRM\Exceptions\AmoCRMApiException;
+use AmoCRM\Models\AccountDomainModel;
 
 include_once __DIR__ . '/bootstrap.php';
 

--- a/src/AmoCRM/Client/AmoCRMApiClient.php
+++ b/src/AmoCRM/Client/AmoCRMApiClient.php
@@ -386,7 +386,7 @@ class AmoCRMApiClient
      * @return CatalogElements
      * @throws InvalidArgumentException|AmoCRMMissedTokenException
      */
-    public function catalogElements(int $catalogId = null)
+    public function catalogElements(?int $catalogId = null)
     {
         $request = $this->buildRequest();
         $service = new CatalogElements($request);
@@ -444,7 +444,7 @@ class AmoCRMApiClient
      * @return CustomFieldGroups
      * @throws InvalidArgumentException|AmoCRMMissedTokenException
      */
-    public function customFieldGroups(string $entityType = null)
+    public function customFieldGroups(?string $entityType = null)
     {
         $request = $this->buildRequest();
 

--- a/src/AmoCRM/EntitiesServices/Account.php
+++ b/src/AmoCRM/EntitiesServices/Account.php
@@ -89,7 +89,7 @@ class Account extends BaseEntity
      * @return BaseApiCollection|null
      * @throws NotAvailableForActionException
      */
-    public function get(BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
+    public function get(?BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
     {
         throw new NotAvailableForActionException('Use getCurrent for this entity');
     }

--- a/src/AmoCRM/EntitiesServices/BaseEntity.php
+++ b/src/AmoCRM/EntitiesServices/BaseEntity.php
@@ -75,7 +75,7 @@ abstract class BaseEntity
      * @throws AmoCRMApiException
      * @throws AmoCRMoAuthApiException
      */
-    public function get(BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
+    public function get(?BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
     {
         $queryParams = [];
         if ($filter instanceof BaseEntityFilter) {

--- a/src/AmoCRM/EntitiesServices/Calls.php
+++ b/src/AmoCRM/EntitiesServices/Calls.php
@@ -153,7 +153,7 @@ class Calls extends BaseEntity
      * @return BaseApiCollection|null
      * @throws NotAvailableForActionException
      */
-    public function get(BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
+    public function get(?BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
     {
         throw new NotAvailableForActionException('Method not available for this entity');
     }

--- a/src/AmoCRM/EntitiesServices/CatalogElements.php
+++ b/src/AmoCRM/EntitiesServices/CatalogElements.php
@@ -24,7 +24,7 @@ use AmoCRM\Models\CatalogElementModel;
  * @package AmoCRM\EntitiesServices
  *
  * @method null|CatalogElementModel getOne($id, array $with = [])
- * @method null|CatalogElementsCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|CatalogElementsCollection get(?BaseEntityFilter $filter = null, array $with = [])
  * @method CatalogElementModel addOne(BaseApiModel $model)
  * @method CatalogElementsCollection add(BaseApiCollection $collection)
  * @method CatalogElementModel updateOne(BaseApiModel $apiModel)

--- a/src/AmoCRM/EntitiesServices/Catalogs.php
+++ b/src/AmoCRM/EntitiesServices/Catalogs.php
@@ -19,7 +19,7 @@ use AmoCRM\Models\CatalogModel;
  * @package AmoCRM\EntitiesServices
  *
  * @method null|CatalogModel getOne($id, array $with = [])
- * @method null|CatalogsCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|CatalogsCollection get(?BaseEntityFilter $filter = null, array $with = [])
  * @method CatalogModel addOne(BaseApiModel $model)
  * @method CatalogsCollection add(BaseApiCollection $collection)
  * @method CatalogModel updateOne(BaseApiModel $apiModel)

--- a/src/AmoCRM/EntitiesServices/Chats/Templates.php
+++ b/src/AmoCRM/EntitiesServices/Chats/Templates.php
@@ -28,7 +28,7 @@ use AmoCRM\Models\Chats\Templates\TemplateModel;
  * @package AmoCRM\EntitiesServices\Chats
  *
  * @method null|TemplateModel getOne($id, array $with = [])
- * @method null|TemplatesCollection get(TemplatesFilter $filter = null, array $with = [])
+ * @method null|TemplatesCollection get(?TemplatesFilter $filter = null, array $with = [])
  * @method TemplateModel updateOne(BaseApiModel $apiModel)
  * @method TemplatesCollection update(BaseApiCollection $collection)
  * @method TemplateModel syncOne(BaseApiModel $apiModel, $with = [])

--- a/src/AmoCRM/EntitiesServices/Companies.php
+++ b/src/AmoCRM/EntitiesServices/Companies.php
@@ -20,7 +20,7 @@ use AmoCRM\Models\CompanyModel;
  * @package AmoCRM\EntitiesServices
  *
  * @method null|CompanyModel getOne($id, array $with = [])
- * @method null|CompaniesCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|CompaniesCollection get(?BaseEntityFilter $filter = null, array $with = [])
  * @method CompanyModel addOne(BaseApiModel $model)
  * @method CompaniesCollection add(BaseApiCollection $collection)
  * @method CompanyModel updateOne(BaseApiModel $apiModel)

--- a/src/AmoCRM/EntitiesServices/Contacts.php
+++ b/src/AmoCRM/EntitiesServices/Contacts.php
@@ -20,7 +20,7 @@ use AmoCRM\Models\ContactModel;
  * @package AmoCRM\EntitiesServices
  *
  * @method null|ContactModel getOne($id, array $with = [])
- * @method null|ContactsCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|ContactsCollection get(?BaseEntityFilter $filter = null, array $with = [])
  * @method ContactModel addOne(BaseApiModel $model)
  * @method ContactsCollection add(BaseApiCollection $collection)
  * @method ContactModel updateOne(BaseApiModel $apiModel)

--- a/src/AmoCRM/EntitiesServices/Currencies.php
+++ b/src/AmoCRM/EntitiesServices/Currencies.php
@@ -18,7 +18,7 @@ use AmoCRM\Models\BaseApiModel;
 
 /**
  * @since Release Spring 2022
- * @method null|CurrenciesCollection get(CurrenciesFilter $filter = null, array $with = [])
+ * @method null|CurrenciesCollection get(?CurrenciesFilter $filter = null, array $with = [])
  */
 class Currencies extends BaseEntity implements HasPageMethodsInterface
 {

--- a/src/AmoCRM/EntitiesServices/CustomFieldGroups.php
+++ b/src/AmoCRM/EntitiesServices/CustomFieldGroups.php
@@ -21,7 +21,7 @@ use AmoCRM\Models\CustomFieldGroupModel;
  * @package AmoCRM\EntitiesServices
  *
  * @method null|CustomFieldGroupModel getOne($id, array $with = [])
- * @method null|CustomFieldGroupsCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|CustomFieldGroupsCollection get(?BaseEntityFilter $filter = null, array $with = [])
  * @method CustomFieldGroupModel addOne(BaseApiModel $model)
  * @method CustomFieldGroupsCollection add(BaseApiCollection $collection)
  * @method CustomFieldGroupModel updateOne(BaseApiModel $apiModel)

--- a/src/AmoCRM/EntitiesServices/CustomFields.php
+++ b/src/AmoCRM/EntitiesServices/CustomFields.php
@@ -25,7 +25,7 @@ use AmoCRM\Models\Interfaces\HasIdInterface;
  *
  * @package AmoCRM\EntitiesServices
  *
- * @method null|CustomFieldsCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|CustomFieldsCollection get(?BaseEntityFilter $filter = null, array $with = [])
  */
 class CustomFields extends BaseEntityTypeEntity implements HasDeleteMethodInterface, HasPageMethodsInterface
 {

--- a/src/AmoCRM/EntitiesServices/Customers/Customers.php
+++ b/src/AmoCRM/EntitiesServices/Customers/Customers.php
@@ -26,7 +26,7 @@ use AmoCRM\Models\Customers\CustomerModel;
  * @package AmoCRM\EntitiesServices\Customers
  *
  * @method null|CustomerModel getOne($id, array $with = [])
- * @method null|CustomersCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|CustomersCollection get(?BaseEntityFilter $filter = null, array $with = [])
  * @method CustomerModel addOne(BaseApiModel $model)
  * @method CustomersCollection add(BaseApiCollection $collection)
  * @method CustomerModel updateOne(BaseApiModel $apiModel)

--- a/src/AmoCRM/EntitiesServices/Customers/Statuses.php
+++ b/src/AmoCRM/EntitiesServices/Customers/Statuses.php
@@ -22,7 +22,7 @@ use AmoCRM\Models\Customers\Statuses\StatusModel;
  * @package AmoCRM\EntitiesServices\Leads
  *
  * @method null|StatusModel getOne($id, array $with = [])
- * @method null|StatusesCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|StatusesCollection get(?BaseEntityFilter $filter = null, array $with = [])
  * @method StatusModel addOne(BaseApiModel $model)
  * @method StatusesCollection add(BaseApiCollection $collection)
  * @method StatusModel updateOne(BaseApiModel $apiModel)

--- a/src/AmoCRM/EntitiesServices/Customers/Transactions.php
+++ b/src/AmoCRM/EntitiesServices/Customers/Transactions.php
@@ -22,7 +22,7 @@ use AmoCRM\Models\Customers\Transactions\TransactionModel;
  * @package AmoCRM\EntitiesServices\Customers
  *
  * @method null|TransactionModel getOne($id, array $with = [])
- * @method null|TransactionsCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|TransactionsCollection get(?BaseEntityFilter $filter = null, array $with = [])
  * @method TransactionModel syncOne(BaseApiModel $apiModel, $with = [])
  */
 class Transactions extends BaseEntity implements HasDeleteMethodInterface

--- a/src/AmoCRM/EntitiesServices/EntityFiles.php
+++ b/src/AmoCRM/EntitiesServices/EntityFiles.php
@@ -38,7 +38,7 @@ class EntityFiles extends BaseEntityTypeEntityIdEntity implements HasDeleteMetho
      * @throws AmoCRMApiException
      * @throws AmoCRMoAuthApiException
      */
-    public function get(BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
+    public function get(?BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
     {
         $queryParams = [];
         if ($filter instanceof BaseEntityFilter) {

--- a/src/AmoCRM/EntitiesServices/EntityNotes.php
+++ b/src/AmoCRM/EntitiesServices/EntityNotes.php
@@ -24,13 +24,13 @@ use AmoCRM\Models\NoteModel;
  *
  * @package AmoCRM\EntitiesServices
  *
- * @method null|NotesCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|NotesCollection get(?BaseEntityFilter $filter = null, array $with = [])
  * @method NoteModel addOne(BaseApiModel $model)
  * @method NotesCollection add(BaseApiCollection $collection)
  * @method NoteModel updateOne(BaseApiModel $apiModel)
  * @method NotesCollection update(BaseApiCollection $collection)
  * @method NoteModel syncOne(BaseApiModel $apiModel, $with = [])
- * @method null|NotesCollection getByParentId(int $parentId, BaseEntityFilter $filter = null, array $with = [])
+ * @method null|NotesCollection getByParentId(int $parentId, ?BaseEntityFilter $filter = null, array $with = [])
  */
 class EntityNotes extends BaseEntityTypeEntity implements HasPageMethodsInterface, HasParentEntity
 {

--- a/src/AmoCRM/EntitiesServices/EntitySubscriptions.php
+++ b/src/AmoCRM/EntitiesServices/EntitySubscriptions.php
@@ -22,7 +22,7 @@ use AmoCRM\Helpers\EntityTypesInterface;
 use AmoCRM\Models\BaseApiModel;
 
 /**
- * @method null|SubscriptionsCollection getByParentId(int $parentId, BaseEntityFilter $filter = null, array $with = [])
+ * @method null|SubscriptionsCollection getByParentId(int $parentId, ?BaseEntityFilter $filter = null, array $with = [])
  */
 class EntitySubscriptions extends BaseEntityTypeEntity implements HasPageMethodsInterface, HasParentEntity
 {
@@ -149,7 +149,7 @@ class EntitySubscriptions extends BaseEntityTypeEntity implements HasPageMethods
      * @throws AmoCRMApiException
      * @throws AmoCRMoAuthApiException
      */
-    public function get(BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
+    public function get(?BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
     {
         throw new NotAvailableForActionException('Method not available for this entity');
     }

--- a/src/AmoCRM/EntitiesServices/EntityTags.php
+++ b/src/AmoCRM/EntitiesServices/EntityTags.php
@@ -22,7 +22,7 @@ use function array_key_exists;
  *
  * @package AmoCRM\EntitiesServices
  *
- * @method null|TagsCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|TagsCollection get(?BaseEntityFilter $filter = null, array $with = [])
  * @method TagModel addOne(BaseApiModel $model)
  * @method TagsCollection add(BaseApiCollection $collection)
  */

--- a/src/AmoCRM/EntitiesServices/EventTypes.php
+++ b/src/AmoCRM/EntitiesServices/EventTypes.php
@@ -19,7 +19,7 @@ use AmoCRM\Models\EventTypeModel;
  *
  * @package AmoCRM\EntitiesServices
  *
- * @method null|EventTypesCollections get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|EventTypesCollections get(?BaseEntityFilter $filter = null, array $with = [])
  */
 class EventTypes extends BaseEntity
 {

--- a/src/AmoCRM/EntitiesServices/Events.php
+++ b/src/AmoCRM/EntitiesServices/Events.php
@@ -20,7 +20,7 @@ use AmoCRM\Models\EventModel;
  * @package AmoCRM\EntitiesServices
  *
  * @method null|EventModel getOne($id, array $with = [])
- * @method null|EventsCollections get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|EventsCollections get(?BaseEntityFilter $filter = null, array $with = [])
  */
 class Events extends BaseEntity implements HasPageMethodsInterface
 {

--- a/src/AmoCRM/EntitiesServices/HasLinkMethodInterface.php
+++ b/src/AmoCRM/EntitiesServices/HasLinkMethodInterface.php
@@ -28,7 +28,7 @@ interface HasLinkMethodInterface
      *
      * @return LinksCollection
      */
-    public function getLinks(BaseApiModel $model, LinksFilter $filter = null): LinksCollection;
+    public function getLinks(BaseApiModel $model, ?LinksFilter $filter = null): LinksCollection;
 
     /**
      * @param BaseApiModel $mainEntity

--- a/src/AmoCRM/EntitiesServices/Leads.php
+++ b/src/AmoCRM/EntitiesServices/Leads.php
@@ -27,7 +27,7 @@ use function is_null;
  * @package AmoCRM\EntitiesServices
  *
  * @method null|LeadModel getOne($id, array $with = [])
- * @method null|LeadsCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|LeadsCollection get(?BaseEntityFilter $filter = null, array $with = [])
  * @method LeadModel addOne(BaseApiModel $model)
  * @method LeadsCollection add(BaseApiCollection $collection)
  * @method LeadModel updateOne(BaseApiModel $apiModel)

--- a/src/AmoCRM/EntitiesServices/Leads/LossReasons.php
+++ b/src/AmoCRM/EntitiesServices/Leads/LossReasons.php
@@ -22,7 +22,7 @@ use AmoCRM\Models\Leads\LossReasons\LossReasonModel;
  * @package AmoCRM\EntitiesServices\Leads
  *
  * @method null|LossReasonModel getOne($id, array $with = [])
- * @method null|LossReasonsCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|LossReasonsCollection get(?BaseEntityFilter $filter = null, array $with = [])
  * @method LossReasonModel addOne(LossReasonModel $model)
  * @method LossReasonsCollection add(BaseApiCollection $collection)
  * @method LossReasonModel updateOne(LossReasonModel $apiModel)

--- a/src/AmoCRM/EntitiesServices/Leads/Pipelines.php
+++ b/src/AmoCRM/EntitiesServices/Leads/Pipelines.php
@@ -23,7 +23,7 @@ use AmoCRM\Models\Leads\Pipelines\PipelineModel;
  * @package AmoCRM\EntitiesServices\Leads
  *
  * @method null|PipelineModel getOne($id, array $with = [])
- * @method null|PipelinesCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|PipelinesCollection get(?BaseEntityFilter $filter = null, array $with = [])
  * @method PipelineModel addOne(BaseApiModel $model)
  * @method PipelinesCollection add(BaseApiCollection $collection)
  * @method PipelineModel updateOne(BaseApiModel $apiModel)

--- a/src/AmoCRM/EntitiesServices/Leads/Statuses.php
+++ b/src/AmoCRM/EntitiesServices/Leads/Statuses.php
@@ -24,7 +24,7 @@ use Exception;
  * @package AmoCRM\EntitiesServices\Leads
  *
  * @method null|StatusModel getOne($id, array $with = [])
- * @method null|StatusesCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|StatusesCollection get(?BaseEntityFilter $filter = null, array $with = [])
  * @method StatusModel addOne(BaseApiModel $model)
  * @method StatusesCollection add(BaseApiCollection $collection)
  * @method StatusModel updateOne(BaseApiModel $apiModel)

--- a/src/AmoCRM/EntitiesServices/Links.php
+++ b/src/AmoCRM/EntitiesServices/Links.php
@@ -38,7 +38,7 @@ class Links extends BaseEntityTypeEntity
      * @throws AmoCRMApiException
      * @throws AmoCRMoAuthApiException
      */
-    public function get(BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
+    public function get(?BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
     {
         $queryParams = [];
         if ($filter instanceof BaseEntityFilter) {

--- a/src/AmoCRM/EntitiesServices/Products.php
+++ b/src/AmoCRM/EntitiesServices/Products.php
@@ -61,7 +61,7 @@ class Products extends BaseEntity
      * @return BaseApiCollection|null
      * @throws NotAvailableForActionException
      */
-    public function get(BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
+    public function get(?BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
     {
         throw new NotAvailableForActionException('Method not available for this entity');
     }

--- a/src/AmoCRM/EntitiesServices/Roles.php
+++ b/src/AmoCRM/EntitiesServices/Roles.php
@@ -24,7 +24,7 @@ use AmoCRM\Models\RoleModel;
  * @package AmoCRM\EntitiesServices
  *
  * @method null|RoleModel getOne($id, array $with = [])
- * @method null|RolesCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|RolesCollection get(?BaseEntityFilter $filter = null, array $with = [])
  * @method RoleModel addOne(BaseApiModel $model)
  * @method RolesCollection add(BaseApiCollection $collection)
  * @method RoleModel updateOne(BaseApiModel $apiModel)

--- a/src/AmoCRM/EntitiesServices/Segments.php
+++ b/src/AmoCRM/EntitiesServices/Segments.php
@@ -23,7 +23,7 @@ use AmoCRM\Models\Customers\Segments\SegmentModel;
  * @package AmoCRM\EntitiesServices
  *
  * @method null|SegmentModel getOne($id, array $with = [])
- * @method null|SegmentsCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|SegmentsCollection get(?BaseEntityFilter $filter = null, array $with = [])
  * @method SegmentModel updateOne(BaseApiModel $apiModel)
  * @method SegmentModel syncOne(BaseApiModel $apiModel, $with = [])
  */

--- a/src/AmoCRM/EntitiesServices/Sources.php
+++ b/src/AmoCRM/EntitiesServices/Sources.php
@@ -19,7 +19,7 @@ use AmoCRM\Models\SourceModel;
  *
  * @package AmoCRM\EntitiesServices
  *
- * @method null|SourcesCollection get(SourcesFilter $filter = null, array $with = [])
+ * @method null|SourcesCollection get(?SourcesFilter $filter = null, array $with = [])
  * @method SourceModel addOne(SourceModel $model)
  * @method SourcesCollection add(SourcesCollection $collection)
  * @method SourceModel updateOne(SourceModel $model)

--- a/src/AmoCRM/EntitiesServices/Sources/WebsiteButtons.php
+++ b/src/AmoCRM/EntitiesServices/Sources/WebsiteButtons.php
@@ -24,7 +24,7 @@ use AmoCRM\Models\Sources\WebsiteButtonUpdateRequestModel;
 
 /**
  * @method WebsiteButtonModel|null getOne($id, array $with = [])
- * @method WebsiteButtonsCollection|null get(BaseEntityFilter $filter = null, array $with = [])
+ * @method WebsiteButtonsCollection|null get(?BaseEntityFilter $filter = null, array $with = [])
  */
 class WebsiteButtons extends BaseEntity
 {

--- a/src/AmoCRM/EntitiesServices/Talks.php
+++ b/src/AmoCRM/EntitiesServices/Talks.php
@@ -36,7 +36,7 @@ class Talks extends BaseEntity
         return $response[AmoCRMApiRequest::EMBEDDED][EntityTypesInterface::TALKS] ?? [];
     }
 
-    public function get(BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
+    public function get(?BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
     {
         throw new NotAvailableForActionException('Method not available for this entity');
     }

--- a/src/AmoCRM/EntitiesServices/Tasks.php
+++ b/src/AmoCRM/EntitiesServices/Tasks.php
@@ -18,7 +18,7 @@ use AmoCRM\Models\TaskModel;
  *
  * @package AmoCRM\EntitiesServices
  * @method null|TaskModel getOne($id, array $with = [])
- * @method null|TasksCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|TasksCollection get(?BaseEntityFilter $filter = null, array $with = [])
  * @method TaskModel addOne(BaseApiModel $model)
  * @method TasksCollection add(BaseApiCollection $collection)
  * @method TaskModel updateOne(BaseApiModel $apiModel)

--- a/src/AmoCRM/EntitiesServices/Traits/LinkMethodsTrait.php
+++ b/src/AmoCRM/EntitiesServices/Traits/LinkMethodsTrait.php
@@ -54,7 +54,7 @@ trait LinkMethodsTrait
      * @throws AmoCRMApiException
      * @throws AmoCRMoAuthApiException
      */
-    public function getLinks(BaseApiModel $model, LinksFilter $filter = null): LinksCollection
+    public function getLinks(BaseApiModel $model, ?LinksFilter $filter = null): LinksCollection
     {
         $queryParams = [];
         if ($filter instanceof BaseEntityFilter) {

--- a/src/AmoCRM/EntitiesServices/Traits/WithParentEntityMethodsTrait.php
+++ b/src/AmoCRM/EntitiesServices/Traits/WithParentEntityMethodsTrait.php
@@ -135,7 +135,7 @@ trait WithParentEntityMethodsTrait
      * @throws AmoCRMApiException
      * @throws AmoCRMoAuthApiException
      */
-    public function getByParentId(int $parentId, BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
+    public function getByParentId(int $parentId, ?BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
     {
         $queryParams = [];
         if ($filter instanceof BaseEntityFilter) {

--- a/src/AmoCRM/EntitiesServices/Unsorted.php
+++ b/src/AmoCRM/EntitiesServices/Unsorted.php
@@ -34,7 +34,7 @@ use AmoCRM\Models\Unsorted\UnsortedSummaryModel;
  * @package AmoCRM\EntitiesServices
  *
  * @method null|BaseUnsortedModel getOne($id, array $with = [])
- * @method null|UnsortedCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|UnsortedCollection get(?BaseEntityFilter $filter = null, array $with = [])
  */
 class Unsorted extends BaseEntity implements HasPageMethodsInterface
 {

--- a/src/AmoCRM/EntitiesServices/Users.php
+++ b/src/AmoCRM/EntitiesServices/Users.php
@@ -21,7 +21,7 @@ use AmoCRM\Models\UserModel;
  *
  * @package AmoCRM\EntitiesServices
  * @method null|UserModel getOne($id, array $with = [])
- * @method null|UsersCollection get(BaseEntityFilter $filter = null, array $with = [])
+ * @method null|UsersCollection get(?BaseEntityFilter $filter = null, array $with = [])
  * @method UserModel addOne(BaseApiModel $model)
  * @method UsersCollection add(BaseApiCollection $collection)
  * @method UserModel syncOne(BaseApiModel $apiModel, $with = [])

--- a/src/AmoCRM/EntitiesServices/Webhooks.php
+++ b/src/AmoCRM/EntitiesServices/Webhooks.php
@@ -18,7 +18,7 @@ use AmoCRM\Models\BaseApiModel;
  *
  * @package AmoCRM\EntitiesServices
  *
- * @method null|WebhooksCollection get(WebhookModel $filter = null, array $with = [])
+ * @method null|WebhooksCollection get(?WebhookModel $filter = null, array $with = [])
  */
 class Webhooks extends BaseEntity
 {

--- a/src/AmoCRM/Models/AccountDomainModel.php
+++ b/src/AmoCRM/Models/AccountDomainModel.php
@@ -137,7 +137,7 @@ class AccountDomainModel extends BaseApiModel
      *
      * @return array
      */
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return $this->toArray();
     }

--- a/src/AmoCRM/Models/BaseApiModel.php
+++ b/src/AmoCRM/Models/BaseApiModel.php
@@ -25,7 +25,7 @@ abstract class BaseApiModel
      * @param string|null $requestId
      * @return array
      */
-    abstract public function toApi(string $requestId = null): array;
+    abstract public function toApi(?string $requestId = null): array;
 
     public function __get($name)
     {

--- a/src/AmoCRM/Models/BotDisposableTokenModel.php
+++ b/src/AmoCRM/Models/BotDisposableTokenModel.php
@@ -256,7 +256,7 @@ class BotDisposableTokenModel extends BaseApiModel
      *
      * @return array
      */
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return $this->toArray();
     }

--- a/src/AmoCRM/Models/Chats/Templates/ReviewModel.php
+++ b/src/AmoCRM/Models/Chats/Templates/ReviewModel.php
@@ -50,7 +50,7 @@ class ReviewModel extends BaseApiModel
         ];
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return $this->toArray();
     }

--- a/src/AmoCRM/Models/CurrencyModel.php
+++ b/src/AmoCRM/Models/CurrencyModel.php
@@ -58,7 +58,7 @@ class CurrencyModel extends BaseApiModel
      *
      * @return string[]
      */
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return $this->toArray();
     }

--- a/src/AmoCRM/Models/CustomFieldGroupModel.php
+++ b/src/AmoCRM/Models/CustomFieldGroupModel.php
@@ -197,7 +197,7 @@ class CustomFieldGroupModel extends BaseApiModel
      * @param string|null $requestId
      * @return array
      */
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         $result = [];
 

--- a/src/AmoCRM/Models/CustomFieldsValues/BaseCustomFieldValuesModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/BaseCustomFieldValuesModel.php
@@ -145,7 +145,7 @@ class BaseCustomFieldValuesModel extends BaseApiModel
         ];
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         $values = $this->getValues();
         return [

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/BaseCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/BaseCustomFieldValueModel.php
@@ -58,7 +58,7 @@ class BaseCustomFieldValueModel extends BaseApiModel
         ];
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => $this->getValue(),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/BaseEnumCodeCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/BaseEnumCodeCustomFieldValueModel.php
@@ -89,7 +89,7 @@ class BaseEnumCodeCustomFieldValueModel extends BaseCustomFieldValueModel
         ];
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => $this->getValue(),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/BaseEnumCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/BaseEnumCustomFieldValueModel.php
@@ -61,7 +61,7 @@ class BaseEnumCustomFieldValueModel extends BaseCustomFieldValueModel
         ];
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => $this->getValue(),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/ChainedListCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/ChainedListCustomFieldValueModel.php
@@ -54,7 +54,7 @@ class ChainedListCustomFieldValueModel extends BaseCustomFieldValueModel
         ];
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'catalog_id' => $this->getCatalogId(),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/DateCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/DateCustomFieldValueModel.php
@@ -63,7 +63,7 @@ class DateCustomFieldValueModel extends BaseCustomFieldValueModel
      *
      * @return array
      */
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => $this->value->format(DateTime::RFC3339),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/FileCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/FileCustomFieldValueModel.php
@@ -116,7 +116,7 @@ class FileCustomFieldValueModel extends BaseCustomFieldValueModel
     /**
      * @return array{value: array{file_uuid?: string, version_uuid?: string, file_name?: string, file_size?: int}}
      */
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => [

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/ItemsCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/ItemsCustomFieldValueModel.php
@@ -480,7 +480,7 @@ class ItemsCustomFieldValueModel extends BaseCustomFieldValueModel
     }
 
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         $result = [
             self::FIELD_SKU => $this->getSku(),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/LegalEntityCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/LegalEntityCustomFieldValueModel.php
@@ -446,7 +446,7 @@ class LegalEntityCustomFieldValueModel extends BaseArrayCustomFieldValueModel
         return $this->toArray();
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => $this->getValue(),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/LinkedEntityCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/LinkedEntityCustomFieldValueModel.php
@@ -153,7 +153,7 @@ class LinkedEntityCustomFieldValueModel extends BaseArrayCustomFieldValueModel
     }
 
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => $this->getValue(),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/MultitextCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/MultitextCustomFieldValueModel.php
@@ -55,7 +55,7 @@ class MultitextCustomFieldValueModel extends BaseEnumCustomFieldValueModel
         return $model;
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => $this->getValue(),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/PayerCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/PayerCustomFieldValueModel.php
@@ -665,7 +665,7 @@ class PayerCustomFieldValueModel extends BaseArrayCustomFieldValueModel
      *
      * @return array
      */
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => $this->getValue(),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/SupplierCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/SupplierCustomFieldValueModel.php
@@ -319,7 +319,7 @@ class SupplierCustomFieldValueModel extends BaseArrayCustomFieldValueModel
      *
      * @return array
      */
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => [

--- a/src/AmoCRM/Models/DisposableTokenModel.php
+++ b/src/AmoCRM/Models/DisposableTokenModel.php
@@ -243,7 +243,7 @@ class DisposableTokenModel extends BaseApiModel
      *
      * @return array
      */
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return $this->toArray();
     }

--- a/src/AmoCRM/Models/InvoiceWarningModel.php
+++ b/src/AmoCRM/Models/InvoiceWarningModel.php
@@ -31,7 +31,7 @@ class InvoiceWarningModel extends BaseApiModel
         ];
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return $this->toArray();
     }

--- a/src/AmoCRM/Models/Sources/SourceServiceModel.php
+++ b/src/AmoCRM/Models/Sources/SourceServiceModel.php
@@ -51,7 +51,7 @@ class SourceServiceModel extends BaseApiModel implements Arrayable
         return $result;
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return $this->toArray();
     }

--- a/src/AmoCRM/Models/Sources/SourceServicePageModel.php
+++ b/src/AmoCRM/Models/Sources/SourceServicePageModel.php
@@ -42,7 +42,7 @@ class SourceServicePageModel extends BaseApiModel implements Arrayable
         ];
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return $this->toArray();
     }

--- a/src/AmoCRM/Models/Sources/SourceServiceParams.php
+++ b/src/AmoCRM/Models/Sources/SourceServiceParams.php
@@ -25,7 +25,7 @@ class SourceServiceParams extends BaseApiModel
         ];
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return $this->toArray();
     }

--- a/src/AmoCRM/OAuth/AmoCRMOAuth.php
+++ b/src/AmoCRM/OAuth/AmoCRMOAuth.php
@@ -49,6 +49,7 @@ use function sprintf;
 
 /**
  * Class AmoCRMOAuth
+ *
  * @package AmoCRM\OAuth
  */
 class AmoCRMOAuth
@@ -129,6 +130,7 @@ class AmoCRMOAuth
 
     /**
      * Получение Access токена по коду авторизации
+     *
      * @param string $code
      *
      * @return AccessTokenInterface
@@ -155,6 +157,7 @@ class AmoCRMOAuth
 
     /**
      * Получение нового Access токена по Refresh токену
+     *
      * @param AccessTokenInterface $accessToken
      *
      * @return AccessTokenInterface
@@ -228,6 +231,7 @@ class AmoCRMOAuth
 
     /**
      * Установка базового домена, куда будут отправляться запросы необходимые для работы с токенами
+     *
      * @param string $domain
      *
      * @return $this
@@ -241,6 +245,7 @@ class AmoCRMOAuth
 
     /**
      * Установка протокола
+     *
      * @param string $protocol
      *
      * @return $this
@@ -278,6 +283,7 @@ class AmoCRMOAuth
 
     /**
      * Получение авторизационных заголовков для переданного Access токена
+     *
      * @param AccessTokenInterface $accessToken
      *
      * @return array
@@ -299,6 +305,7 @@ class AmoCRMOAuth
 
     /**
      * Установка Callback при обновлении Access токена по
+     *
      * @param callable $function
      *
      * @return AmoCRMOAuth
@@ -312,6 +319,7 @@ class AmoCRMOAuth
 
     /**
      * Получение данных о том, кому принадлежит токен
+     *
      * @param AccessTokenInterface $accessToken
      *
      * @return ResourceOwnerInterface
@@ -432,7 +440,6 @@ class AmoCRMOAuth
     }
 
     /**
-     * @deprecated
      * Получение субдомена аккаунта по токену
      *
      * @param AccessTokenInterface $accessToken
@@ -441,6 +448,8 @@ class AmoCRMOAuth
      * @throws AmoCRMApiErrorResponseException
      * @throws AmoCRMApiConnectExceptionException
      * @throws AmoCRMApiHttpClientException
+     *
+     * @deprecated
      */
     public function getAccountDomain(AccessTokenInterface $accessToken): AccountDomainModel
     {
@@ -604,7 +613,7 @@ class AmoCRMOAuth
      * @throws DisposableTokenVerificationFailedException
      * @link https://www.amocrm.ru/developers/content/web_sdk/mechanics
      */
-    public function parseBotDisposableToken(string $token, string $receiverPath = null): BotDisposableTokenModel
+    public function parseBotDisposableToken(string $token, ?string $receiverPath = null): BotDisposableTokenModel
     {
         $signer = new Sha512();
         $key = InMemory::plainText($this->clientSecret);
@@ -651,6 +660,7 @@ class AmoCRMOAuth
      * Получает домен для общих api методов из access токена, домен присутствует в токенах выписанных после 21.08.2024
      *
      * @param AccessTokenInterface $accessToken
+     *
      * @return string
      *
      * @throws InvalidArgumentException

--- a/src/AmoCRM/OAuth/OAuthServiceInterface.php
+++ b/src/AmoCRM/OAuth/OAuthServiceInterface.php
@@ -16,7 +16,7 @@ interface OAuthServiceInterface
 {
     /**
      * @param AccessTokenInterface $accessToken
-     * @param string               $baseDomain
+     * @param string $baseDomain
      */
     public function saveOAuthToken(AccessTokenInterface $accessToken, string $baseDomain): void;
 }

--- a/src/AmoCRM/Support/Str.php
+++ b/src/AmoCRM/Support/Str.php
@@ -21,7 +21,8 @@ class Str
     /**
      * Convert the given string to upper-case.
      *
-     * @param  string  $value
+     * @param string $value
+     *
      * @return string
      */
     public static function upper($value)
@@ -32,9 +33,10 @@ class Str
     /**
      * Returns the portion of the string specified by the start and length parameters.
      *
-     * @param  string  $string
-     * @param  int  $start
-     * @param  int|null  $length
+     * @param string $string
+     * @param int $start
+     * @param int|null $length
+     *
      * @return string
      */
     public static function substr($string, $start, $length = null)
@@ -45,7 +47,8 @@ class Str
     /**
      * Make a string's first character uppercase.
      *
-     * @param  string  $string
+     * @param string $string
+     *
      * @return string
      */
     public static function ucfirst($string)
@@ -56,7 +59,8 @@ class Str
     /**
      * Convert a value to studly caps case.
      *
-     * @param  string  $value
+     * @param string $value
+     *
      * @return string
      */
     public static function studly($value)
@@ -79,7 +83,8 @@ class Str
     /**
      * Convert a value to camel case.
      *
-     * @param  string  $value
+     * @param string $value
+     *
      * @return string
      */
     public static function camel($value)
@@ -94,9 +99,10 @@ class Str
     /**
      * Replace the given value in the given string.
      *
-     * @param  string|string[]  $search
-     * @param  string|string[]  $replace
-     * @param  string|string[]  $subject
+     * @param string|string[] $search
+     * @param string|string[] $replace
+     * @param string|string[] $subject
+     *
      * @return string
      */
     public static function replace($search, $replace, $subject)

--- a/tests/Cases/AmoCRM/Client/AmoCRMApiClientTest.php
+++ b/tests/Cases/AmoCRM/Client/AmoCRMApiClientTest.php
@@ -148,8 +148,7 @@ class AmoCRMApiClientTest extends TestCase
     {
         $this->assertInstanceOf(
             AmoCRMApiClient::class,
-            $this->apiClient->setRefreshAccessTokenCallback(function () {
-            })
+            $this->apiClient->setRefreshAccessTokenCallback(function () {})
         );
         $callback = $this->_getInnerPropertyValueByReflection('refreshAccessTokenCallback');
         $this->assertIsCallable($callback);

--- a/tests/Cases/AmoCRM/Filters/EventsFilterTest.php
+++ b/tests/Cases/AmoCRM/Filters/EventsFilterTest.php
@@ -42,10 +42,11 @@ class EventsFilterTest extends TestCase
         $this->assertNull($this->eventsFilter->getEntityIds());
     }
 
-      /**
+    /**
      * @return array
      */
-    public function getInvalidArrayOrNumericFilter() {
+    public function getInvalidArrayOrNumericFilter()
+    {
         return [
             [
                 -1,
@@ -53,7 +54,7 @@ class EventsFilterTest extends TestCase
             [
                 [
                     -1,
-                    -100
+                    -100,
                 ],
             ],
             [
@@ -62,27 +63,28 @@ class EventsFilterTest extends TestCase
                 ],
             ],
             [
-                "hello"
+                "hello",
             ],
             [
                 [
                     true,
-                    false
-                ]
+                    false,
+                ],
             ],
             [
-                false
+                false,
             ],
             [
-                null
+                null,
             ],
         ];
     }
 
-     /**
+    /**
      * @return array
      */
-    public function getValidArrayOrNumericFilter() {
+    public function getValidArrayOrNumericFilter()
+    {
         return [
             [
                 0, [0],
@@ -97,8 +99,8 @@ class EventsFilterTest extends TestCase
                 [1, 2, 3, 4], [1, 2, 3, 4],
             ],
             [
-                [-1, 1, 2], [1 , 2],
-            ]
+                [-1, 1, 2], [1, 2],
+            ],
         ];
     }
 }

--- a/tests/Cases/AmoCRM/Filters/LeadsFilterTest.php
+++ b/tests/Cases/AmoCRM/Filters/LeadsFilterTest.php
@@ -322,7 +322,7 @@ class LeadsFilterTest extends TestCase
     public function testInvalidStatuses()
     {
         $statuses = [
-            '123'
+            '123',
         ];
         $this->leadsFilter->setStatuses($statuses);
         $this->assertNull($this->leadsFilter->getStatuses());
@@ -378,7 +378,8 @@ class LeadsFilterTest extends TestCase
     /**
      * @return array
      */
-    public function getValidArrayOrStringFilter() {
+    public function getValidArrayOrStringFilter()
+    {
         return [
             [
                 "hello", ["hello"],
@@ -395,7 +396,8 @@ class LeadsFilterTest extends TestCase
     /**
      * @return array
      */
-    public function getValidArrayOrNumericFilter() {
+    public function getValidArrayOrNumericFilter()
+    {
         return [
             [
                 0, [0],
@@ -410,15 +412,16 @@ class LeadsFilterTest extends TestCase
                 [1, 2, 3, 4], [1, 2, 3, 4],
             ],
             [
-                [-1, 1, 2], [1 , 2],
-            ]
+                [-1, 1, 2], [1, 2],
+            ],
         ];
     }
 
     /**
      * @return array
      */
-    public function getInvalidArrayOrStringFilter() {
+    public function getInvalidArrayOrStringFilter()
+    {
         return [
             [
                 -1,
@@ -426,7 +429,7 @@ class LeadsFilterTest extends TestCase
             [
                 [
                     -1,
-                    -100
+                    -100,
                 ],
             ],
             [
@@ -435,19 +438,19 @@ class LeadsFilterTest extends TestCase
                 ],
             ],
             [
-                100
+                100,
             ],
             [
                 [
                     true,
-                    false
-                ]
+                    false,
+                ],
             ],
             [
-                false
+                false,
             ],
             [
-                null
+                null,
             ],
         ];
     }
@@ -455,7 +458,8 @@ class LeadsFilterTest extends TestCase
     /**
      * @return array
      */
-    public function getInvalidArrayOrNumericFilter() {
+    public function getInvalidArrayOrNumericFilter()
+    {
         return [
             [
                 -1,
@@ -463,7 +467,7 @@ class LeadsFilterTest extends TestCase
             [
                 [
                     -1,
-                    -100
+                    -100,
                 ],
             ],
             [
@@ -472,19 +476,19 @@ class LeadsFilterTest extends TestCase
                 ],
             ],
             [
-                "hello"
+                "hello",
             ],
             [
                 [
                     true,
-                    false
-                ]
+                    false,
+                ],
             ],
             [
-                false
+                false,
             ],
             [
-                null
+                null,
             ],
         ];
     }
@@ -492,7 +496,8 @@ class LeadsFilterTest extends TestCase
     /**
      * @return array
      */
-    public function getValidIntOrIntRangeFilter() {
+    public function getValidIntOrIntRangeFilter()
+    {
         return [
             [
                 (new BaseRangeFilter())
@@ -509,7 +514,8 @@ class LeadsFilterTest extends TestCase
     /**
      * @return array
      */
-    public function getInvalidIntOrIntRangeFilter() {
+    public function getInvalidIntOrIntRangeFilter()
+    {
         return [
             [
                 -1,
@@ -517,7 +523,7 @@ class LeadsFilterTest extends TestCase
             [
                 [
                     -1,
-                    -100
+                    -100,
                 ],
             ],
             [
@@ -526,19 +532,19 @@ class LeadsFilterTest extends TestCase
                 ],
             ],
             [
-                "hello"
+                "hello",
             ],
             [
                 [
                     true,
-                    false
-                ]
+                    false,
+                ],
             ],
             [
-                false
+                false,
             ],
             [
-                null
+                null,
             ],
             [
                 "1", 1,

--- a/tests/Cases/AmoCRM/Models/CustomFieldsValues/ValueModel/DateCustomFieldValueModelTest.php
+++ b/tests/Cases/AmoCRM/Models/CustomFieldsValues/ValueModel/DateCustomFieldValueModelTest.php
@@ -27,7 +27,7 @@ final class DateCustomFieldValueModelTest extends TestCase
             [null], // null
             [[123]], // array
             [false], // bool
-            [new stdClass()] //object
+            [new stdClass()], //object
         ];
     }
 

--- a/tests/Cases/CustomField/NestedFieldTest.php
+++ b/tests/Cases/CustomField/NestedFieldTest.php
@@ -55,12 +55,12 @@ class NestedFieldTest extends TestCase
     public function testFullToApiMethod(): void
     {
         $correctResult = [
-            'request_id'        => 'Request1',
+            'request_id' => 'Request1',
             'parent_request_id' => 'ParentRequest1',
-            'sort'              => 1,
-            'value'             => 'value123',
-            'id'                => 123,
-            'parent_id'         => 1234,
+            'sort' => 1,
+            'value' => 'value123',
+            'id' => 123,
+            'parent_id' => 1234,
         ];
 
         $model = (new NestedModel())

--- a/tests/Cases/Rights/CatalogRightsTest.php
+++ b/tests/Cases/Rights/CatalogRightsTest.php
@@ -16,16 +16,16 @@ class CatalogRightsTest extends TestCase
         $rightsData = [];
         $caseAllOk = [
             [
-                RightModel::ACTION_ADD    => RightModel::RIGHTS_FULL,
-                RightModel::ACTION_VIEW   => RightModel::RIGHTS_FULL,
-                RightModel::ACTION_EDIT   => RightModel::RIGHTS_LINKED,
+                RightModel::ACTION_ADD => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_VIEW => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_EDIT => RightModel::RIGHTS_LINKED,
                 RightModel::ACTION_DELETE => RightModel::RIGHTS_DENIED,
                 RightModel::ACTION_EXPORT => RightModel::RIGHTS_FULL,
             ],
             [
-                RightModel::ACTION_ADD    => RightModel::RIGHTS_FULL,
-                RightModel::ACTION_VIEW   => RightModel::RIGHTS_FULL,
-                RightModel::ACTION_EDIT   => RightModel::RIGHTS_LINKED,
+                RightModel::ACTION_ADD => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_VIEW => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_EDIT => RightModel::RIGHTS_LINKED,
                 RightModel::ACTION_DELETE => RightModel::RIGHTS_DENIED,
                 RightModel::ACTION_EXPORT => RightModel::RIGHTS_FULL,
             ],
@@ -34,16 +34,16 @@ class CatalogRightsTest extends TestCase
 
         $caseWrongPriority = [
             [
-                RightModel::ACTION_ADD    => RightModel::RIGHTS_FULL,
-                RightModel::ACTION_VIEW   => RightModel::RIGHTS_LINKED,
-                RightModel::ACTION_EDIT   => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_ADD => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_VIEW => RightModel::RIGHTS_LINKED,
+                RightModel::ACTION_EDIT => RightModel::RIGHTS_FULL,
                 RightModel::ACTION_DELETE => RightModel::RIGHTS_LINKED,
                 RightModel::ACTION_EXPORT => RightModel::RIGHTS_FULL,
             ],
             [
-                RightModel::ACTION_ADD    => RightModel::RIGHTS_FULL,
-                RightModel::ACTION_VIEW   => RightModel::RIGHTS_LINKED,
-                RightModel::ACTION_EDIT   => RightModel::RIGHTS_LINKED,
+                RightModel::ACTION_ADD => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_VIEW => RightModel::RIGHTS_LINKED,
+                RightModel::ACTION_EDIT => RightModel::RIGHTS_LINKED,
                 RightModel::ACTION_DELETE => RightModel::RIGHTS_LINKED,
                 RightModel::ACTION_EXPORT => RightModel::RIGHTS_LINKED,
             ],
@@ -52,16 +52,16 @@ class CatalogRightsTest extends TestCase
 
         $caseWrongPerm = [
             [
-                RightModel::ACTION_ADD    => RightModel::RIGHTS_FULL,
-                RightModel::ACTION_VIEW   => RightModel::RIGHTS_FULL,
-                RightModel::ACTION_EDIT   => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_ADD => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_VIEW => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_EDIT => RightModel::RIGHTS_FULL,
                 RightModel::ACTION_DELETE => RightModel::RIGHTS_ONLY_RESPONSIBLE,
                 RightModel::ACTION_EXPORT => RightModel::RIGHTS_FULL,
             ],
             [
-                RightModel::ACTION_ADD    => RightModel::RIGHTS_FULL,
-                RightModel::ACTION_VIEW   => RightModel::RIGHTS_FULL,
-                RightModel::ACTION_EDIT   => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_ADD => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_VIEW => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_EDIT => RightModel::RIGHTS_FULL,
                 RightModel::ACTION_DELETE => RightModel::RIGHTS_DENIED,
                 RightModel::ACTION_EXPORT => RightModel::RIGHTS_FULL,
             ],
@@ -70,14 +70,14 @@ class CatalogRightsTest extends TestCase
 
         $caseEmptyAction = [
             [
-                RightModel::ACTION_ADD    => RightModel::RIGHTS_FULL,
-                RightModel::ACTION_VIEW   => RightModel::RIGHTS_FULL,
-                RightModel::ACTION_EDIT   => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_ADD => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_VIEW => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_EDIT => RightModel::RIGHTS_FULL,
             ],
             [
-                RightModel::ACTION_ADD    => RightModel::RIGHTS_FULL,
-                RightModel::ACTION_VIEW   => RightModel::RIGHTS_FULL,
-                RightModel::ACTION_EDIT   => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_ADD => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_VIEW => RightModel::RIGHTS_FULL,
+                RightModel::ACTION_EDIT => RightModel::RIGHTS_FULL,
                 RightModel::ACTION_DELETE => RightModel::RIGHTS_DENIED,
                 RightModel::ACTION_EXPORT => RightModel::RIGHTS_DENIED,
             ],


### PR DESCRIPTION
In php8.4 syntax like `public function toApi(string $requestId = null)` are DEPRECATED.
This pull-request fix it

in my projects on php8.4 i receive many log errors like:
```
ERROR  PHP Deprecated: AmoCRM\Client\AmoCRMApiClient::catalogElements(): Implicitly marking parameter $catalogId as nullable is deprecated, the explicit nullable type must be used instead in vendor/amocrm/amocrm-api-library/src/AmoCRM/Client/AmoCRMApiClient.php on line 389.
```