### PR TITLE
(INTEGR-1998) поправил коллекции и запросы для CallNote

### DIFF
--- a/src/AmoCRM/Models/CustomFieldsValues/ValueCollections/LegalEntityCustomFieldValueCollection.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueCollections/LegalEntityCustomFieldValueCollection.php
@@ -2,6 +2,8 @@
 
 namespace AmoCRM\Models\CustomFieldsValues\ValueCollections;
 
+use AmoCRM\Models\CustomFieldsValues\ValueModels\LegalEntityCustomFieldValueModel;
+
 /**
  * Class LegalEntityCustomFieldValueCollection
  *
@@ -9,4 +11,5 @@ namespace AmoCRM\Models\CustomFieldsValues\ValueCollections;
  */
 class LegalEntityCustomFieldValueCollection extends BaseCustomFieldValueCollection
 {
+    public const ITEM_CLASS = LegalEntityCustomFieldValueModel::class;
 }

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueCollections/LinkedEntityCustomFieldValueCollection.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueCollections/LinkedEntityCustomFieldValueCollection.php
@@ -2,6 +2,8 @@
 
 namespace AmoCRM\Models\CustomFieldsValues\ValueCollections;
 
+use AmoCRM\Models\CustomFieldsValues\ValueModels\LinkedEntityCustomFieldValueModel;
+
 /**
  * Class LinkedEntityCustomFieldValueCollection
  *
@@ -9,4 +11,5 @@ namespace AmoCRM\Models\CustomFieldsValues\ValueCollections;
  */
 class LinkedEntityCustomFieldValueCollection extends BaseCustomFieldValueCollection
 {
+    public const ITEM_CLASS = LinkedEntityCustomFieldValueModel::class;
 }

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueCollections/MultitextCustomFieldValueCollection.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueCollections/MultitextCustomFieldValueCollection.php
@@ -2,6 +2,8 @@
 
 namespace AmoCRM\Models\CustomFieldsValues\ValueCollections;
 
+use AmoCRM\Models\CustomFieldsValues\ValueModels\MultitextCustomFieldValueModel;
+
 /**
  * Class MultitextCustomFieldValueCollection
  *
@@ -9,4 +11,5 @@ namespace AmoCRM\Models\CustomFieldsValues\ValueCollections;
  */
 class MultitextCustomFieldValueCollection extends BaseCustomFieldValueCollection
 {
+    public const ITEM_CLASS = MultitextCustomFieldValueModel::class;
 }

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueCollections/PayerCustomFieldValueCollection.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueCollections/PayerCustomFieldValueCollection.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace AmoCRM\Models\CustomFieldsValues\ValueCollections;
 
+use AmoCRM\Models\CustomFieldsValues\ValueModels\PayerCustomFieldValueModel;
+
 /**
  * Class PayerCustomFieldValueCollection
  *
@@ -11,4 +13,5 @@ namespace AmoCRM\Models\CustomFieldsValues\ValueCollections;
  */
 class PayerCustomFieldValueCollection extends BaseCustomFieldValueCollection
 {
+    public const ITEM_CLASS = PayerCustomFieldValueModel::class;
 }

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueCollections/SupplierCustomFieldValueCollection.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueCollections/SupplierCustomFieldValueCollection.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace AmoCRM\Models\CustomFieldsValues\ValueCollections;
 
+use AmoCRM\Models\CustomFieldsValues\ValueModels\SupplierCustomFieldValueModel;
+
 /**
  * Class SupplierCustomFieldValueCollection
  *
@@ -11,4 +13,5 @@ namespace AmoCRM\Models\CustomFieldsValues\ValueCollections;
  */
 class SupplierCustomFieldValueCollection extends BaseCustomFieldValueCollection
 {
+    public const ITEM_CLASS = SupplierCustomFieldValueModel::class;
 }

--- a/src/AmoCRM/Models/NoteType/CallNote.php
+++ b/src/AmoCRM/Models/NoteType/CallNote.php
@@ -91,10 +91,19 @@ abstract class CallNote extends NoteModel
             'source' => $this->getSource(),
             'link' => $this->getLink(),
             'phone' => $this->getPhone(),
-            'call_result' => $this->getCallResult(),
-            'call_status' => $this->getCallStatus(),
-            'call_responsible' => $this->getCallResponsible(),
         ];
+
+        if ($this->getCallResult() !== null) {
+            $result['params']['call_result'] = $this->getCallResult();
+        }
+
+        if ($this->getCallStatus() !== null) {
+            $result['params']['call_status'] = $this->getCallStatus();
+        }
+
+        if ($this->getCallResponsible() !== null) {
+            $result['params']['call_responsible'] = $this->getCallResponsible();
+        }
 
         return $result;
     }


### PR DESCRIPTION
Для следующих моделей коллекции некорректно обрабатывали методы `getBy()`, `replaceBy()` и т.д.
```
MultitextCustomFieldValueModel
LegalEntityCustomFieldValueModel
LinkedEntityCustomFieldValueModel
PayerCustomFieldValueModel
SupplierCustomFieldValueModel
```
Пофиксил с помощью переопределения `ITEM_CLASS` в соответствующих коллекциях

Также запросы на создание/обновление примечаний `CallNote` падали с Bad Request, если в них не засетить, например, callResult, так как запрос не проходил валидацию, потому что callResult не может быть null

Это необязательные параметры, которые не указаны в документации, поэтому добавил проверку на null, чтобы они не кидались в тело запроса