### PR TITLE
fix implicitly nullable parameters for php 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require": {
     "php": ">=7.1 || >=8.0",
     "ext-json": "*",
-    "amocrm/oauth2-amocrm": "^2.0",
+    "amocrm/oauth2-amocrm": "^3.0",
     "guzzlehttp/guzzle": "6.* || 7.*",
     "symfony/dotenv": "3.* || 4.* || 5.* || 6.* || 7.*",
     "fig/http-message-util": "1.*",

--- a/src/AmoCRM/Client/AmoCRMApiClient.php
+++ b/src/AmoCRM/Client/AmoCRMApiClient.php
@@ -386,7 +386,7 @@ class AmoCRMApiClient
      * @return CatalogElements
      * @throws InvalidArgumentException|AmoCRMMissedTokenException
      */
-    public function catalogElements(int $catalogId = null)
+    public function catalogElements(?int $catalogId = null)
     {
         $request = $this->buildRequest();
         $service = new CatalogElements($request);
@@ -444,7 +444,7 @@ class AmoCRMApiClient
      * @return CustomFieldGroups
      * @throws InvalidArgumentException|AmoCRMMissedTokenException
      */
-    public function customFieldGroups(string $entityType = null)
+    public function customFieldGroups(?string $entityType = null)
     {
         $request = $this->buildRequest();
 

--- a/src/AmoCRM/EntitiesServices/Account.php
+++ b/src/AmoCRM/EntitiesServices/Account.php
@@ -83,13 +83,13 @@ class Account extends BaseEntity
     }
 
     /**
-     * @param null|BaseEntityFilter $filter
+     * @param BaseEntityFilter|null $filter
      * @param array $with
      *
      * @return BaseApiCollection|null
      * @throws NotAvailableForActionException
      */
-    public function get(BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
+    public function get(?BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
     {
         throw new NotAvailableForActionException('Use getCurrent for this entity');
     }

--- a/src/AmoCRM/EntitiesServices/BaseEntity.php
+++ b/src/AmoCRM/EntitiesServices/BaseEntity.php
@@ -68,14 +68,14 @@ abstract class BaseEntity
 
     /**
      * Получение коллекции сущностей
-     * @param null|BaseEntityFilter $filter
+     * @param BaseEntityFilter|null $filter
      * @param array $with
      *
      * @return BaseApiCollection|null
      * @throws AmoCRMApiException
      * @throws AmoCRMoAuthApiException
      */
-    public function get(BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
+    public function get(?BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
     {
         $queryParams = [];
         if ($filter instanceof BaseEntityFilter) {

--- a/src/AmoCRM/EntitiesServices/Calls.php
+++ b/src/AmoCRM/EntitiesServices/Calls.php
@@ -153,7 +153,7 @@ class Calls extends BaseEntity
      * @return BaseApiCollection|null
      * @throws NotAvailableForActionException
      */
-    public function get(BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
+    public function get(?BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
     {
         throw new NotAvailableForActionException('Method not available for this entity');
     }

--- a/src/AmoCRM/EntitiesServices/EntityFiles.php
+++ b/src/AmoCRM/EntitiesServices/EntityFiles.php
@@ -38,7 +38,7 @@ class EntityFiles extends BaseEntityTypeEntityIdEntity implements HasDeleteMetho
      * @throws AmoCRMApiException
      * @throws AmoCRMoAuthApiException
      */
-    public function get(BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
+    public function get(?BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
     {
         $queryParams = [];
         if ($filter instanceof BaseEntityFilter) {

--- a/src/AmoCRM/EntitiesServices/EntitySubscriptions.php
+++ b/src/AmoCRM/EntitiesServices/EntitySubscriptions.php
@@ -142,14 +142,14 @@ class EntitySubscriptions extends BaseEntityTypeEntity implements HasPageMethods
     }
 
     /**
-     * @param null|BaseEntityFilter $filter
+     * @param BaseEntityFilter|null $filter
      * @param array $with
      *
      * @return BaseApiCollection|null
      * @throws AmoCRMApiException
      * @throws AmoCRMoAuthApiException
      */
-    public function get(BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
+    public function get(?BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
     {
         throw new NotAvailableForActionException('Method not available for this entity');
     }

--- a/src/AmoCRM/EntitiesServices/HasLinkMethodInterface.php
+++ b/src/AmoCRM/EntitiesServices/HasLinkMethodInterface.php
@@ -28,7 +28,7 @@ interface HasLinkMethodInterface
      *
      * @return LinksCollection
      */
-    public function getLinks(BaseApiModel $model, LinksFilter $filter = null): LinksCollection;
+    public function getLinks(BaseApiModel $model, ?LinksFilter $filter = null): LinksCollection;
 
     /**
      * @param BaseApiModel $mainEntity

--- a/src/AmoCRM/EntitiesServices/Links.php
+++ b/src/AmoCRM/EntitiesServices/Links.php
@@ -38,7 +38,7 @@ class Links extends BaseEntityTypeEntity
      * @throws AmoCRMApiException
      * @throws AmoCRMoAuthApiException
      */
-    public function get(BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
+    public function get(?BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
     {
         $queryParams = [];
         if ($filter instanceof BaseEntityFilter) {

--- a/src/AmoCRM/EntitiesServices/Products.php
+++ b/src/AmoCRM/EntitiesServices/Products.php
@@ -61,7 +61,7 @@ class Products extends BaseEntity
      * @return BaseApiCollection|null
      * @throws NotAvailableForActionException
      */
-    public function get(BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
+    public function get(?BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
     {
         throw new NotAvailableForActionException('Method not available for this entity');
     }

--- a/src/AmoCRM/EntitiesServices/Talks.php
+++ b/src/AmoCRM/EntitiesServices/Talks.php
@@ -36,7 +36,7 @@ class Talks extends BaseEntity
         return $response[AmoCRMApiRequest::EMBEDDED][EntityTypesInterface::TALKS] ?? [];
     }
 
-    public function get(BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
+    public function get(?BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
     {
         throw new NotAvailableForActionException('Method not available for this entity');
     }

--- a/src/AmoCRM/EntitiesServices/Traits/LinkMethodsTrait.php
+++ b/src/AmoCRM/EntitiesServices/Traits/LinkMethodsTrait.php
@@ -54,7 +54,7 @@ trait LinkMethodsTrait
      * @throws AmoCRMApiException
      * @throws AmoCRMoAuthApiException
      */
-    public function getLinks(BaseApiModel $model, LinksFilter $filter = null): LinksCollection
+    public function getLinks(BaseApiModel $model, ?LinksFilter $filter = null): LinksCollection
     {
         $queryParams = [];
         if ($filter instanceof BaseEntityFilter) {

--- a/src/AmoCRM/EntitiesServices/Traits/WithParentEntityMethodsTrait.php
+++ b/src/AmoCRM/EntitiesServices/Traits/WithParentEntityMethodsTrait.php
@@ -128,14 +128,14 @@ trait WithParentEntityMethodsTrait
      * Получение коллекции сущностей по ID родительской сущности
      *
      * @param int $parentId
-     * @param null|BaseEntityFilter $filter
+     * @param BaseEntityFilter|null $filter
      * @param array $with
      *
      * @return BaseApiCollection|null
      * @throws AmoCRMApiException
      * @throws AmoCRMoAuthApiException
      */
-    public function getByParentId(int $parentId, BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
+    public function getByParentId(int $parentId, ?BaseEntityFilter $filter = null, array $with = []): ?BaseApiCollection
     {
         $queryParams = [];
         if ($filter instanceof BaseEntityFilter) {

--- a/src/AmoCRM/Exceptions/AmoCRMApiException.php
+++ b/src/AmoCRM/Exceptions/AmoCRMApiException.php
@@ -45,7 +45,7 @@ class AmoCRMApiException extends Exception
         $code = 0,
         array $lastRequestInfo = [],
         string $description = "",
-        Throwable $previous = null
+        ?Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);
 

--- a/src/AmoCRM/Models/AccountDomainModel.php
+++ b/src/AmoCRM/Models/AccountDomainModel.php
@@ -137,7 +137,7 @@ class AccountDomainModel extends BaseApiModel
      *
      * @return array
      */
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return $this->toArray();
     }

--- a/src/AmoCRM/Models/BaseApiModel.php
+++ b/src/AmoCRM/Models/BaseApiModel.php
@@ -25,7 +25,7 @@ abstract class BaseApiModel
      * @param string|null $requestId
      * @return array
      */
-    abstract public function toApi(string $requestId = null): array;
+    abstract public function toApi(?string $requestId = null): array;
 
     public function __get($name)
     {

--- a/src/AmoCRM/Models/BotDisposableTokenModel.php
+++ b/src/AmoCRM/Models/BotDisposableTokenModel.php
@@ -256,7 +256,7 @@ class BotDisposableTokenModel extends BaseApiModel
      *
      * @return array
      */
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return $this->toArray();
     }

--- a/src/AmoCRM/Models/Chats/Templates/ReviewModel.php
+++ b/src/AmoCRM/Models/Chats/Templates/ReviewModel.php
@@ -50,7 +50,7 @@ class ReviewModel extends BaseApiModel
         ];
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return $this->toArray();
     }

--- a/src/AmoCRM/Models/CurrencyModel.php
+++ b/src/AmoCRM/Models/CurrencyModel.php
@@ -58,7 +58,7 @@ class CurrencyModel extends BaseApiModel
      *
      * @return string[]
      */
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return $this->toArray();
     }

--- a/src/AmoCRM/Models/CustomFieldGroupModel.php
+++ b/src/AmoCRM/Models/CustomFieldGroupModel.php
@@ -197,7 +197,7 @@ class CustomFieldGroupModel extends BaseApiModel
      * @param string|null $requestId
      * @return array
      */
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         $result = [];
 

--- a/src/AmoCRM/Models/CustomFieldsValues/BaseCustomFieldValuesModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/BaseCustomFieldValuesModel.php
@@ -145,7 +145,7 @@ class BaseCustomFieldValuesModel extends BaseApiModel
         ];
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         $values = $this->getValues();
         return [

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/BaseCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/BaseCustomFieldValueModel.php
@@ -58,7 +58,7 @@ class BaseCustomFieldValueModel extends BaseApiModel
         ];
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => $this->getValue(),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/BaseEnumCodeCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/BaseEnumCodeCustomFieldValueModel.php
@@ -89,7 +89,7 @@ class BaseEnumCodeCustomFieldValueModel extends BaseCustomFieldValueModel
         ];
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => $this->getValue(),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/BaseEnumCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/BaseEnumCustomFieldValueModel.php
@@ -61,7 +61,7 @@ class BaseEnumCustomFieldValueModel extends BaseCustomFieldValueModel
         ];
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => $this->getValue(),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/ChainedListCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/ChainedListCustomFieldValueModel.php
@@ -54,7 +54,7 @@ class ChainedListCustomFieldValueModel extends BaseCustomFieldValueModel
         ];
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'catalog_id' => $this->getCatalogId(),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/DateCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/DateCustomFieldValueModel.php
@@ -63,7 +63,7 @@ class DateCustomFieldValueModel extends BaseCustomFieldValueModel
      *
      * @return array
      */
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => $this->value->format(DateTime::RFC3339),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/FileCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/FileCustomFieldValueModel.php
@@ -116,7 +116,7 @@ class FileCustomFieldValueModel extends BaseCustomFieldValueModel
     /**
      * @return array{value: array{file_uuid?: string, version_uuid?: string, file_name?: string, file_size?: int}}
      */
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => [

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/ItemsCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/ItemsCustomFieldValueModel.php
@@ -480,7 +480,7 @@ class ItemsCustomFieldValueModel extends BaseCustomFieldValueModel
     }
 
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         $result = [
             self::FIELD_SKU => $this->getSku(),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/LegalEntityCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/LegalEntityCustomFieldValueModel.php
@@ -446,7 +446,7 @@ class LegalEntityCustomFieldValueModel extends BaseArrayCustomFieldValueModel
         return $this->toArray();
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => $this->getValue(),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/LinkedEntityCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/LinkedEntityCustomFieldValueModel.php
@@ -153,7 +153,7 @@ class LinkedEntityCustomFieldValueModel extends BaseArrayCustomFieldValueModel
     }
 
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => $this->getValue(),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/MultitextCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/MultitextCustomFieldValueModel.php
@@ -55,7 +55,7 @@ class MultitextCustomFieldValueModel extends BaseEnumCustomFieldValueModel
         return $model;
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => $this->getValue(),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/PayerCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/PayerCustomFieldValueModel.php
@@ -665,7 +665,7 @@ class PayerCustomFieldValueModel extends BaseArrayCustomFieldValueModel
      *
      * @return array
      */
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => $this->getValue(),

--- a/src/AmoCRM/Models/CustomFieldsValues/ValueModels/SupplierCustomFieldValueModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/ValueModels/SupplierCustomFieldValueModel.php
@@ -319,7 +319,7 @@ class SupplierCustomFieldValueModel extends BaseArrayCustomFieldValueModel
      *
      * @return array
      */
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return [
             'value' => [

--- a/src/AmoCRM/Models/DisposableTokenModel.php
+++ b/src/AmoCRM/Models/DisposableTokenModel.php
@@ -243,7 +243,7 @@ class DisposableTokenModel extends BaseApiModel
      *
      * @return array
      */
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return $this->toArray();
     }

--- a/src/AmoCRM/Models/InvoiceWarningModel.php
+++ b/src/AmoCRM/Models/InvoiceWarningModel.php
@@ -31,7 +31,7 @@ class InvoiceWarningModel extends BaseApiModel
         ];
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return $this->toArray();
     }

--- a/src/AmoCRM/Models/Sources/SourceServiceModel.php
+++ b/src/AmoCRM/Models/Sources/SourceServiceModel.php
@@ -51,7 +51,7 @@ class SourceServiceModel extends BaseApiModel implements Arrayable
         return $result;
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return $this->toArray();
     }

--- a/src/AmoCRM/Models/Sources/SourceServicePageModel.php
+++ b/src/AmoCRM/Models/Sources/SourceServicePageModel.php
@@ -42,7 +42,7 @@ class SourceServicePageModel extends BaseApiModel implements Arrayable
         ];
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return $this->toArray();
     }

--- a/src/AmoCRM/Models/Sources/SourceServiceParams.php
+++ b/src/AmoCRM/Models/Sources/SourceServiceParams.php
@@ -25,7 +25,7 @@ class SourceServiceParams extends BaseApiModel
         ];
     }
 
-    public function toApi(string $requestId = null): array
+    public function toApi(?string $requestId = null): array
     {
         return $this->toArray();
     }

--- a/src/AmoCRM/OAuth/AmoCRMOAuth.php
+++ b/src/AmoCRM/OAuth/AmoCRMOAuth.php
@@ -604,7 +604,7 @@ class AmoCRMOAuth
      * @throws DisposableTokenVerificationFailedException
      * @link https://www.amocrm.ru/developers/content/web_sdk/mechanics
      */
-    public function parseBotDisposableToken(string $token, string $receiverPath = null): BotDisposableTokenModel
+    public function parseBotDisposableToken(string $token, ?string $receiverPath = null): BotDisposableTokenModel
     {
         $signer = new Sha512();
         $key = InMemory::plainText($this->clientSecret);


### PR DESCRIPTION
Исправляет ту же проблему, что и https://github.com/amocrm/amocrm-api-php/pull/589 но правки более изолированны, затрагивают только возможные причины
```log
Deprecated: Implicitly marking parameter $abc as nullable is deprecated, the explicit nullable type must be used instead
```