### PR TITLE
Fix: handle null custom-fields values in BaseCustomFieldValuesModel::toArray()

### DIFF
--- a/src/AmoCRM/Models/CustomFieldsValues/BaseCustomFieldValuesModel.php
+++ b/src/AmoCRM/Models/CustomFieldsValues/BaseCustomFieldValuesModel.php
@@ -136,12 +136,13 @@ class BaseCustomFieldValuesModel extends BaseApiModel
 
     public function toArray(): array
     {
+        $values = $this->getValues();
         return [
             'field_id' => $this->getFieldId(),
             'field_code' => $this->getFieldCode(),
             'field_name' => $this->getFieldName(),
             'field_type' => $this->getFieldType(),
-            'values' => $this->getValues()->toArray(),
+            'values' => $values ? $values->toArray() : null,
         ];
     }
 


### PR DESCRIPTION
 **Problem**

 `BaseCustomFieldValuesModel::toArray()` calls `$this->getValues()->toArray()` unconditionally. If `getValues()` returns `null`, this causes a fatal error (trying to call `toArray()` on null).

 **Real case**
```
// В Сделке очистим значение поля "дата и время"
$lead = (new LeadModel())->setId(12345);
$customFields = (new CustomFieldsValuesCollection());
$field = (new DateTimeCustomFieldValuesModel())->setFieldId(54321);
$customFields->add($field);
$lead->setCustomFieldsValues($customFields);

$lead->toArray; // выбросит fatal error - trying to call `toArray()` on null
```

 **Fix**

 Guard the call and return `null` for the `values` key when `getValues()` is `null`. When `getValues()` is present, we still call `toArray()` as before.

 **Before**

 ```php
 'values' => $this->getValues()->toArray()
 ```

 **After**

 ```php
 $values = $this->getValues();
 'values' => $values ? $values->toArray() : null
 ```