### PR TITLE
Удаление зависимости lcobucci/clock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
     "amocrm/oauth2-amocrm": "^3.0",
     "fig/http-message-util": "1.*",
     "guzzlehttp/guzzle": "6.* || 7.*",
-    "lcobucci/clock": "1.1.0 ||^2.0.0",
     "lcobucci/jwt": "^3.4.6 || ^4.0.4 || ^5.0",
     "nesbot/carbon": "^2.72.6 || ^3.8.4",
     "ramsey/uuid": "^3 || ^4",


### PR DESCRIPTION
Fixes #599 

`lcobucci/clock` весьма нестабильная зависимость для такой маленькой библиотеки. Уже три мажорных версии. Многие библиотеки подключают её, но не следят за релизами. Поэтому часто встречаю конфликты из-за этой библиотеки. Вот сейчас я столкнулся с проблемой, что ваша библиотека тянет конфликтующую версию `lcobucci/clock`. Но по сути вам `lcobucci/clock` не нужна. Простейшую фабрику текущего времени, которая используется в одном месте, можно реализовать анонимным классом. Это избавит вас от поддержки нескольких версий `lcobucci/clock`.

Если в будущем вам понадобится зависимость от `psr/clock`, используйте, пожалуйста, `Psr\Clock\ClockInterface`, так как есть куча реализаций, которые конфликтуют друг с другом.