### PR TITLE
feat: add metadata oauth button and some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,22 +72,33 @@ $apiClient->setAccessToken($accessToken)
             });
 ```
 
-Отправить пользователя на страницу авторизации можно 2мя способами:
-1. Отрисовав кнопку на сайт:
+Доступные методы отправки на страницу авторизации пользователя
+1. Кнопка установки существующей интеграции по client_id
 ```php
-$apiClient->getOAuthClient()->getOAuthButton(
-            [
-                'title' => 'Установить интеграцию',
-                'compact' => true,
-                'class_name' => 'className',
-                'color' => 'default',
-                'error_callback' => 'handleOauthError',
-                'state' => $state,
-            ]
-        );
+// data-client-id будет взят из API клиента
+$apiClient->getOAuthClient()->getOAuthButton([
+    'title' => 'Установить интеграцию',
+    'compact' => true,
+    'class_name' => 'className',
+    'color' => 'default',
+    'error_callback' => 'handleOauthError',
+    'state' => $state,
+]);
 ```
 
-2. Отправив пользователя на страницу авторизации
+2. Кнопка с метаданными для создания внешней интеграции. Для каждой установки создается отдельная интеграция
+
+```php
+// redirect_uri будет взят из API клиента
+$apiClient->getOAuthClient()->getOAuthButton([
+    'is_metadata' => true, // указываем, что передаем метаданные в кнопку. По умолчанию - false
+    'secrets_uri' => 'https://your-domain.com/secrets'
+    'title' => 'Создать интеграцию',
+    // ... другие параметры
+]);
+```
+
+3. Прямой редирект на страницу авторизации
 ```php
 $authorizationUrl = $apiClient->getOAuthClient()->getAuthorizeUrl([
             'state' => $state,

--- a/examples/oauth_button_actions.php
+++ b/examples/oauth_button_actions.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use AmoCRM\Client\AmoCRMApiClient;
+
+$clientId = 'client_id';
+$clientSecret = 'client_secret';
+
+// Здесь нужны работающие redirect_uri и client_secret
+$redirectUri = 'https://example.com/redirect';
+$secretsUri = 'https://example.com/secrets';
+
+$apiClient = new AmoCRMApiClient($clientId, $clientSecret, $redirectUri);
+
+echo "=== Генерация обычной OAuth кнопки ===\n";
+$buttonByClientId = $apiClient->getOAuthClient()->getOAuthButton(
+    [
+        'title' => 'title_tmedvedevv',
+        'compact' => false,
+        'is_kommo' => true,
+        'class_name' => 'classNameTmedvedevv',
+        'color' => 'red',
+        'mode' => 'popup',
+        'error_callback' => 'handleOauthError'
+    ]
+);
+
+var_dump($buttonByClientId);
+
+echo "\n=== Генерация кнопки с метаданными, необходимые для создания внешней интеграции ===\n";
+
+// Генерируем кнопку с метаданными для внешней интеграции
+// client_id из API клиента будет проигнорирован т.к создается новая интеграция в аккаунте
+// После установки приходит 2 хука.
+
+$buttonMetadata = $apiClient->getOAuthClient()->getOAuthButton([
+    'title' => 'title_tmedvedevv',
+    'compact' => true,
+    'is_kommo' => false,
+    'class_name' => 'classNameTmedvedevv',
+    'color' => 'red',
+    'mode' => 'popup',
+    'error_callback' => 'handleOauthError',
+    'scopes' => ['crm'],
+    'is_metadata' => true, // Указываем, поскольку нужна кнопка с передачей метаданных. По умолчанию false
+    'secrets_uri' => $secretsUri // url куда будут отправлены данные по интеграции
+]);
+
+var_dump($buttonMetadata);

--- a/src/AmoCRM/Exceptions/AmoCRMOAuthButtonConfigurationException.php
+++ b/src/AmoCRM/Exceptions/AmoCRMOAuthButtonConfigurationException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace AmoCRM\Exceptions;
+
+/**
+ * Выбрасывается в случае неверной конфигурации oAuth кнопки
+ */
+class AmoCRMOAuthButtonConfigurationException extends AmoCRMApiException
+{
+}

--- a/tests/Cases/AmoCRM/OAuth/AmoCRMOAuthButtonTest.php
+++ b/tests/Cases/AmoCRM/OAuth/AmoCRMOAuthButtonTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Cases\AmoCRM\OAuth;
+
+use AmoCRM\Exceptions\AmoCRMOAuthButtonConfigurationException;
+use PHPUnit\Framework\TestCase;
+use AmoCRM\OAuth\AmoCRMOAuth;
+
+class AmoCRMOAuthButtonTest extends TestCase
+{
+    /**
+     * @var AmoCRMOAuth
+     */
+    private $oauthClient;
+
+
+    /**
+     * Создаем клиент с client_id для тестирования обычной кнопки
+     */
+    protected function setUp(): void
+    {
+        $this->oauthClient = new AmoCRMOAuth(
+            'test_client_id',
+            'test_secret',
+            'https://example.com/redirect'
+        );
+    }
+
+    /**
+     * Проверяем генерацию обычной кнопки с client_id
+     * @throws AmoCRMOAuthButtonConfigurationException
+     */
+    public function testRegularButtonWithClientId(): void
+    {
+        $result = $this->oauthClient->getOAuthButton([]);
+        $this->assertStringContainsString('data-client-id="test_client_id"', $result);
+        $this->assertStringContainsString('data-title="Установить интеграцию"', $result);
+        $this->assertStringContainsString('data-class-name="className"', $result);
+    }
+
+
+    /**
+     * Проверяем кастомные параметры для обычной кнопки
+     * @throws AmoCRMOAuthButtonConfigurationException
+     */
+    public function testRegularButtonWithCustomOptions(): void
+    {
+        $result = $this->oauthClient->getOAuthButton([
+            'title' => 'Custom Title',
+            'class_name' => 'custom-class',
+            'color' => 'red',
+            'compact' => false,
+            'mode' => 'popup'
+        ]);
+
+        $this->assertStringContainsString('data-title="Custom Title"', $result);
+        $this->assertStringContainsString('data-class-name="custom-class"', $result);
+        $this->assertStringContainsString('data-color="red"', $result);
+        $this->assertStringContainsString('data-compact="false"', $result);
+        $this->assertStringContainsString('data-mode="popup"', $result);
+    }
+
+    /**
+     * Проверяем ошибку при невалидном цвете
+     * @return void
+     * @throws AmoCRMOAuthButtonConfigurationException
+     */
+    public function testInvalidColorThrowsException(): void
+    {
+        $this->expectException(AmoCRMOAuthButtonConfigurationException::class);
+        $this->expectExceptionMessage('Invalid color selected');
+        $this->oauthClient->getOAuthButton(['color' => 'invalid_color']);
+    }
+
+
+    /**
+     * Тест 4: Проверяем генерацию metadata кнопки
+     * @throws AmoCRMOAuthButtonConfigurationException
+     */
+    public function testMetadataButtonGeneration(): void
+    {
+        $result = $this->oauthClient->getOAuthButton([
+            'is_metadata' => true,
+            'name' => 'Test Integration',
+            'description' => 'Test Description',
+            'scopes' => ['crm', 'notifications'],
+            'secrets_uri' => 'https://secrets.com'
+        ]);
+
+        $this->assertStringNotContainsString('data-client-id', $result);
+        $this->assertStringContainsString('data-name="Test Integration"', $result);
+        $this->assertStringContainsString('data-description="Test Description"', $result);
+        $this->assertStringContainsString('data-scopes="crm,notifications"', $result);
+        $this->assertStringContainsString('data-secrets_uri="https://secrets.com"', $result);
+    }
+
+    /**
+     * Должно упасть, если не передали redirect_uri
+     * @return void
+     * @throws AmoCRMOAuthButtonConfigurationException
+     */
+    public function testMetadataButtonWithoutNameThrowsException(): void
+    {
+        $oauthClient = new AmoCRMOAuth(
+            'test_client_id',
+            'test_secret',
+            null
+        );
+
+        $this->expectException(AmoCRMOAuthButtonConfigurationException::class);
+
+
+        $oauthClient->getOAuthButton([
+            'is_metadata' => true,
+            'description' => 'Test',
+            'scopes' => ['crm'],
+            'secrets_uri' => 'https://secrets.com'
+        ]);
+    }
+
+    /**
+     * Проверяем ошибку при невалидных scopes
+     * @return void
+     * @throws AmoCRMOAuthButtonConfigurationException
+     */
+    public function testMetadataButtonWithInvalidScopesThrowsException(): void
+    {
+        $this->expectException(AmoCRMOAuthButtonConfigurationException::class);
+        $this->expectExceptionMessage('Invalid scopes');
+
+        $this->oauthClient->getOAuthButton([
+            'is_metadata' => true,
+            'name' => 'Test',
+            'description' => 'Test',
+            'scopes' => ['invalid_scope', 'another_invalid'],
+            'secrets_uri' => 'https://secrets.com'
+        ]);
+    }
+
+    /**
+     * Проверяем ошибку когда scopes не массив
+     * @return void
+     * @throws AmoCRMOAuthButtonConfigurationException
+     */
+    public function testMetadataButtonWithStringScopesThrowsException(): void
+    {
+        $this->expectException(AmoCRMOAuthButtonConfigurationException::class);
+        $this->expectExceptionMessage('scopes parameter must be an array');
+
+        $this->oauthClient->getOAuthButton([
+            'is_metadata' => true,
+            'name' => 'Test',
+            'description' => 'Test',
+            'scopes' => 'crm,notifications',
+            'secrets_uri' => 'https://secrets.com'
+        ]);
+    }
+
+    /**
+     * Проверяем использование дефолтных scopes когда не переданы
+     * @throws AmoCRMOAuthButtonConfigurationException
+     */
+    public function testMetadataButtonUsesDefaultScopes(): void
+    {
+        $result = $this->oauthClient->getOAuthButton([
+            'is_metadata' => true,
+            'name' => 'Test',
+            'description' => 'Test',
+            'secrets_uri' => 'https://secrets.com'
+            // должны использоваться дефолтные scopes - crm, notifications
+        ]);
+
+        $defaultScopes = implode(',', AmoCRMOAuth::METADATA_BUTTON_AVAILABLE_SCOPES);
+        $this->assertStringContainsString('data-scopes="' . $defaultScopes . '"', $result);
+    }
+
+    /**
+     * Проверяем поддержку Kommo
+     * @throws AmoCRMOAuthButtonConfigurationException
+     */
+    public function testKommoButtonGeneration(): void
+    {
+        $result = $this->oauthClient->getOAuthButton([
+            'is_kommo' => true,
+            'is_metadata' => true,
+            'name' => 'Test',
+            'description' => 'Test',
+            'scopes' => ['crm'],
+            'secrets_uri' => 'https://secrets.com'
+        ]);
+
+        $this->assertStringContainsString('class="kommo_oauth"', $result);
+        $this->assertStringContainsString('kommo.com', $result);
+    }
+
+    /**
+     * Проверяем ошибку при отсутствии secrets_uri для metadata кнопки
+     * @return void
+     * @throws AmoCRMOAuthButtonConfigurationException
+     */
+    public function testMetadataButtonWithoutSecretsUriThrowsException(): void
+    {
+        $this->expectException(AmoCRMOAuthButtonConfigurationException::class);
+        $this->expectExceptionMessage('secrets_uri');
+
+        // Создаем клиент без secrets_uri
+        $clientWithoutSecrets = new AmoCRMOAuth(
+            'test_client_id',
+            'test_secret',
+            'https://redirect.com'
+        );
+
+        $clientWithoutSecrets->getOAuthButton([
+            'is_metadata' => true,
+            'name' => 'Test',
+            'description' => 'Test',
+            'scopes' => ['crm']
+        ]);
+    }
+
+    /**
+     * Проверяем работу с пустым массивом scopes
+     * Должны подставиться дефолтные scopes
+     * @throws AmoCRMOAuthButtonConfigurationException
+     */
+    public function testMetadataButtonWithEmptyScopesArrayUsesDefaults(): void
+    {
+        $result = $this->oauthClient->getOAuthButton([
+            'is_metadata' => true,
+            'name' => 'Test',
+            'description' => 'Test',
+            'scopes' => [], // Пустой массив
+            'secrets_uri' => 'https://secrets.com'
+        ]);
+
+        $defaultScopes = implode(',', AmoCRMOAuth::METADATA_BUTTON_AVAILABLE_SCOPES);
+        $this->assertStringContainsString('data-scopes="' . $defaultScopes . '"', $result);
+    }
+}

--- a/tests/Cases/AmoCRM/OAuth/AmoCRMOAuthTest.php
+++ b/tests/Cases/AmoCRM/OAuth/AmoCRMOAuthTest.php
@@ -10,7 +10,7 @@ use Lcobucci\JWT\Validation\Constraint;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
-class AmoCRMOAuth extends TestCase
+class AmoCRMOAuthTest extends TestCase
 {
     public function testCreateValidAtConstraintReturnsConstraintInstance()
     {


### PR DESCRIPTION
Добавил возможность генерации OAuth кнопки с метаданными для создания внешних интеграций, дополнил README примером использования, добавил рабочий пример в папку examples, реализовал кастомный эксепшен для обработки ошибок конфигурации кнопки, написал тесты для добавленного функционала. Исправил название тестового класса с AmoCRMOAuth на AmoCRMOAuthTest.